### PR TITLE
cynara: wrap unit testing as ptest

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -23,10 +23,33 @@ CXXFLAGS_append = " \
 
 EXTRA_OECMAKE += " \
 -DCMAKE_VERBOSE_MAKEFILE=ON \
--DBUILD_TESTS:BOOL=OFF \
 -DCMAKE_BUILD_TYPE=RELEASE \
 -DSYSTEMD_SYSTEM_UNITDIR=${systemd_unitdir}/system \
 "
+
+# Testing depends on gmock and gtest. They can be found in meta-oe
+# and are not necessarily available, so this feature is off by default.
+# If gmock from meta-oe is used, then a workaround is needed to avoid
+# a link error (libgmock.a calls pthread functions without libpthread
+# being listed in the .pc file).
+PACKAGECONFIG[tests] = "-DBUILD_TESTS:BOOL=ON,-DBUILD_TESTS:BOOL=OFF,gmock gtest,"
+SRC_URI_append = "${@bb.utils.contains('PACKAGECONFIG', 'tests', ' file://gmock-pthread-linking.patch file://run-ptest', '', d)}"
+
+# Will be empty if no tests were built.
+inherit ptest
+FILES_${PN}-ptest += "${bindir}/cynara-tests ${bindir}/cynara-db-migration-tests ${localstatedir}/cynara/tests"
+do_install_ptest () {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'tests', 'true', 'false', d)}; then
+        mkdir -p ${D}/${localstatedir}/cynara/tests
+        cp -r ${S}/test/db/* ${D}/${localstatedir}/cynara/tests
+    fi
+}
+
+do_compile_prepend () {
+    # en_US.UTF8 is not available, causing cynara-tests parser.getKeyAndValue to fail.
+    # Submitted upstream: https://github.com/Samsung/cynara/issues/10
+    sed -i -e 's/std::locale("en_US.UTF8")/std::locale("C")/g' ${S}/test/credsCommons/parser/Parser.cpp
+}
 
 inherit useradd
 USERADD_PACKAGES = "${PN}"

--- a/meta-security-framework/recipes-security/cynara/cynara/PolicyKeyFeature-avoid-complex-global-constants.patch
+++ b/meta-security-framework/recipes-security/cynara/cynara/PolicyKeyFeature-avoid-complex-global-constants.patch
@@ -1,0 +1,83 @@
+From 4cd8acab5a05500107ae508ed28741239d710f81 Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Fri, 29 May 2015 12:41:34 +0200
+Subject: [PATCH] PolicyKeyFeature: avoid complex global constants
+
+PolicyKeyFeature is used by other global instances in cynara-test
+and cannot assume that the initialization of its own static constants
+happens first, unless it enforces initialization by embedding
+these constants in method calls.
+
+Upstream-status: Submitted [https://github.com/Samsung/cynara/issues/9]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ src/common/types/PolicyKey.cpp | 11 +++++++++--
+ src/common/types/PolicyKey.h   | 12 ++++++------
+ 2 files changed, 15 insertions(+), 8 deletions(-)
+
+diff --git a/src/common/types/PolicyKey.cpp b/src/common/types/PolicyKey.cpp
+index ffb1400..d5631c2 100644
+--- a/src/common/types/PolicyKey.cpp
++++ b/src/common/types/PolicyKey.cpp
+@@ -29,8 +29,15 @@
+ 
+ namespace Cynara {
+ 
+-const std::string PolicyKeyFeature::m_wildcardValue = CYNARA_ADMIN_WILDCARD;
+-const std::string PolicyKeyFeature::m_anyValue = CYNARA_ADMIN_ANY;
++const std::string &PolicyKeyFeature::wildcardValue() {
++    static const std::string value(CYNARA_ADMIN_WILDCARD);
++    return value;
++}
++
++const std::string &PolicyKeyFeature::anyValue() {
++    static const std::string value(CYNARA_ADMIN_ANY);
++    return value;
++}
+ 
+ const std::string &PolicyKeyFeature::toString(void) const {
+     return value();
+diff --git a/src/common/types/PolicyKey.h b/src/common/types/PolicyKey.h
+index 4fed189..d5253c6 100644
+--- a/src/common/types/PolicyKey.h
++++ b/src/common/types/PolicyKey.h
+@@ -49,11 +49,11 @@ public:
+     }
+ 
+     static PolicyKeyFeature createWildcard(void) {
+-        return PolicyKeyFeature(m_wildcardValue);
++        return PolicyKeyFeature(wildcardValue());
+     }
+ 
+     static PolicyKeyFeature createAny(void) {
+-        return PolicyKeyFeature(m_anyValue);
++        return PolicyKeyFeature(anyValue());
+     }
+ 
+     // TODO: Different features (client, user, privilege)
+@@ -86,8 +86,8 @@ public:
+ 
+ protected:
+     explicit PolicyKeyFeature(const ValueType &value) : m_value(value),
+-        m_isWildcard(value == PolicyKeyFeature::m_wildcardValue),
+-        m_isAny(value == PolicyKeyFeature::m_anyValue) {}
++        m_isWildcard(value == wildcardValue()),
++        m_isAny(value == anyValue()) {}
+ 
+     static bool anyAny(const PolicyKeyFeature &pkf1, const PolicyKeyFeature &pkf2) {
+         return pkf1.isAny() || pkf2.isAny();
+@@ -106,8 +106,8 @@ private:
+     bool m_isWildcard;
+     bool m_isAny;
+ 
+-    const static std::string m_wildcardValue;
+-    const static std::string m_anyValue;
++    const static std::string &wildcardValue();
++    const static std::string &anyValue();
+ };
+ 
+ class PolicyKey
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/cynara/cynara/globals-avoid-copying-other-globals.patch
+++ b/meta-security-framework/recipes-security/cynara/cynara/globals-avoid-copying-other-globals.patch
@@ -1,0 +1,183 @@
+From 418aa1d621bf8bf50a9cbe5d9994b48ced0b29e1 Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Fri, 29 May 2015 13:11:47 +0200
+Subject: [PATCH] globals: avoid copying other globals
+
+In several places, a global constant is initialized with the constant
+of another constant of the same type. This only works if these
+instances happen to be initialized in the right order, which is not
+guaranteed and indeed happened to fail when using gcc 4.9 (see
+https://github.com/Samsung/cynara/issues/9).
+
+The solution used here replaces the copies of the other constants with
+references to them, which minimizes source code changes and is also
+slightly more efficient. The references can be created at any time
+because the address of the real constants cannot change.
+
+This change was enough to get cynara-tests running; it is not necessarily
+complete.
+
+Upstream-status: Submitted [https://github.com/Samsung/cynara/issues/9]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ src/storage/ChecksumValidator.cpp                | 4 ++--
+ src/storage/ChecksumValidator.h                  | 4 ++--
+ src/storage/InMemoryStorageBackend.cpp           | 8 ++++----
+ src/storage/InMemoryStorageBackend.h             | 8 ++++----
+ src/storage/Integrity.cpp                        | 8 ++++----
+ src/storage/Integrity.h                          | 8 ++++----
+ test/chsgen/checksumgenerator.cpp                | 2 +-
+ test/storage/checksum/checksumvalidator.cpp      | 2 +-
+ test/storage/checksum/checksumvalidatorfixture.h | 2 +-
+ 9 files changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/src/storage/ChecksumValidator.cpp b/src/storage/ChecksumValidator.cpp
+index 1354ad1..b0898a7 100644
+--- a/src/storage/ChecksumValidator.cpp
++++ b/src/storage/ChecksumValidator.cpp
+@@ -38,8 +38,8 @@
+ 
+ namespace Cynara {
+ 
+-const std::string ChecksumValidator::m_checksumFilename(PathConfig::StoragePath::checksumFilename);
+-const std::string ChecksumValidator::m_backupFilenameSuffix(
++const std::string &ChecksumValidator::m_checksumFilename(PathConfig::StoragePath::checksumFilename);
++const std::string &ChecksumValidator::m_backupFilenameSuffix(
+         PathConfig::StoragePath::backupFilenameSuffix);
+ 
+ void ChecksumValidator::load(std::istream &stream) {
+diff --git a/src/storage/ChecksumValidator.h b/src/storage/ChecksumValidator.h
+index bfd577b..94a6edb 100644
+--- a/src/storage/ChecksumValidator.h
++++ b/src/storage/ChecksumValidator.h
+@@ -56,8 +56,8 @@ protected:
+ 
+     Checksums m_sums;
+     const std::string m_dbPath;
+-    static const std::string m_checksumFilename;
+-    static const std::string m_backupFilenameSuffix;
++    static const std::string &m_checksumFilename;
++    static const std::string &m_backupFilenameSuffix;
+ };
+ 
+ } // namespace Cynara
+diff --git a/src/storage/InMemoryStorageBackend.cpp b/src/storage/InMemoryStorageBackend.cpp
+index 15f6a8a..69f74b9 100644
+--- a/src/storage/InMemoryStorageBackend.cpp
++++ b/src/storage/InMemoryStorageBackend.cpp
+@@ -53,11 +53,11 @@
+ 
+ namespace Cynara {
+ 
+-const std::string InMemoryStorageBackend::m_chsFilename(PathConfig::StoragePath::checksumFilename);
+-const std::string InMemoryStorageBackend::m_indexFilename(PathConfig::StoragePath::indexFilename);
+-const std::string InMemoryStorageBackend::m_backupFilenameSuffix(
++const std::string &InMemoryStorageBackend::m_chsFilename(PathConfig::StoragePath::checksumFilename);
++const std::string &InMemoryStorageBackend::m_indexFilename(PathConfig::StoragePath::indexFilename);
++const std::string &InMemoryStorageBackend::m_backupFilenameSuffix(
+         PathConfig::StoragePath::backupFilenameSuffix);
+-const std::string InMemoryStorageBackend::m_bucketFilenamePrefix(
++const std::string &InMemoryStorageBackend::m_bucketFilenamePrefix(
+         PathConfig::StoragePath::bucketFilenamePrefix);
+ 
+ InMemoryStorageBackend::InMemoryStorageBackend(const std::string &path) : m_dbPath(path),
+diff --git a/src/storage/InMemoryStorageBackend.h b/src/storage/InMemoryStorageBackend.h
+index 80a505c..9e232c0 100644
+--- a/src/storage/InMemoryStorageBackend.h
++++ b/src/storage/InMemoryStorageBackend.h
+@@ -86,10 +86,10 @@ private:
+     Buckets m_buckets;
+     ChecksumValidator m_checksum;
+     Integrity m_integrity;
+-    static const std::string m_chsFilename;
+-    static const std::string m_indexFilename;
+-    static const std::string m_backupFilenameSuffix;
+-    static const std::string m_bucketFilenamePrefix;
++    static const std::string &m_chsFilename;
++    static const std::string &m_indexFilename;
++    static const std::string &m_backupFilenameSuffix;
++    static const std::string &m_bucketFilenamePrefix;
+ 
+ protected:
+     virtual Buckets &buckets(void) {
+diff --git a/src/storage/Integrity.cpp b/src/storage/Integrity.cpp
+index 0b8e583..e0ed638 100644
+--- a/src/storage/Integrity.cpp
++++ b/src/storage/Integrity.cpp
+@@ -40,10 +40,10 @@ namespace Cynara {
+ 
+ namespace StorageConfig = PathConfig::StoragePath;
+ 
+-const std::string Integrity::m_guardFilename(StorageConfig::guardFilename);
+-const std::string Integrity::m_indexFilename(StorageConfig::indexFilename);
+-const std::string Integrity::m_backupFilenameSuffix(StorageConfig::backupFilenameSuffix);
+-const std::string Integrity::m_bucketFilenamePrefix(StorageConfig::bucketFilenamePrefix);
++const std::string &Integrity::m_guardFilename(StorageConfig::guardFilename);
++const std::string &Integrity::m_indexFilename(StorageConfig::indexFilename);
++const std::string &Integrity::m_backupFilenameSuffix(StorageConfig::backupFilenameSuffix);
++const std::string &Integrity::m_bucketFilenamePrefix(StorageConfig::bucketFilenamePrefix);
+ 
+ bool Integrity::backupGuardExists(void) const {
+     struct stat buffer;
+diff --git a/src/storage/Integrity.h b/src/storage/Integrity.h
+index 569ca85..df1c4fc 100644
+--- a/src/storage/Integrity.h
++++ b/src/storage/Integrity.h
+@@ -60,10 +60,10 @@ protected:
+ 
+ private:
+     const std::string m_dbPath;
+-    static const std::string m_indexFilename;
+-    static const std::string m_backupFilenameSuffix;
+-    static const std::string m_bucketFilenamePrefix;
+-    static const std::string m_guardFilename;
++    static const std::string &m_indexFilename;
++    static const std::string &m_backupFilenameSuffix;
++    static const std::string &m_bucketFilenamePrefix;
++    static const std::string &m_guardFilename;
+ };
+ 
+ } // namespace Cynara
+diff --git a/test/chsgen/checksumgenerator.cpp b/test/chsgen/checksumgenerator.cpp
+index 1d390d6..83cdc3f 100644
+--- a/test/chsgen/checksumgenerator.cpp
++++ b/test/chsgen/checksumgenerator.cpp
+@@ -33,7 +33,7 @@
+ namespace {
+ 
+ const std::string execName("./cynara-db-chsgen");
+-const std::string backupFilenameSuffix(Cynara::PathConfig::StoragePath::backupFilenameSuffix);
++const std::string &backupFilenameSuffix(Cynara::PathConfig::StoragePath::backupFilenameSuffix);
+ const char fieldSeparator(Cynara::PathConfig::StoragePath::fieldSeparator);
+ 
+ } // namespace
+diff --git a/test/storage/checksum/checksumvalidator.cpp b/test/storage/checksum/checksumvalidator.cpp
+index 19918f3..4e4088f 100644
+--- a/test/storage/checksum/checksumvalidator.cpp
++++ b/test/storage/checksum/checksumvalidator.cpp
+@@ -41,7 +41,7 @@ using namespace Cynara;
+ const std::string ChecksumValidatorFixture::m_dbPath("/fake/path/");
+ const std::string ChecksumValidatorFixture::m_filename("fakeFilename");
+ const std::string ChecksumValidatorFixture::m_checksum("$1$$fakeChecksum");
+-const std::string ChecksumValidatorFixture::m_backupFilenameSuffix(
++const std::string &ChecksumValidatorFixture::m_backupFilenameSuffix(
+         PathConfig::StoragePath::backupFilenameSuffix);
+ const char ChecksumValidatorFixture::m_fieldSeparator(PathConfig::StoragePath::fieldSeparator);
+ const char ChecksumValidatorFixture::m_recordSeparator(PathConfig::StoragePath::recordSeparator);
+diff --git a/test/storage/checksum/checksumvalidatorfixture.h b/test/storage/checksum/checksumvalidatorfixture.h
+index 6fb28f6..559473e 100644
+--- a/test/storage/checksum/checksumvalidatorfixture.h
++++ b/test/storage/checksum/checksumvalidatorfixture.h
+@@ -45,7 +45,7 @@ protected:
+     static const std::string m_dbPath;
+     static const std::string m_filename;
+     static const std::string m_checksum;
+-    static const std::string m_backupFilenameSuffix;
++    static const std::string &m_backupFilenameSuffix;
+     static const char m_fieldSeparator;
+     static const char m_recordSeparator;
+     static const size_t m_firstLine;
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/cynara/cynara/gmock-pthread-linking.patch
+++ b/meta-security-framework/recipes-security/cynara/cynara/gmock-pthread-linking.patch
@@ -1,0 +1,31 @@
+From 80cc04091410d6a322fee1a2922fdf867395f00a Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Fri, 29 May 2015 10:21:57 +0200
+Subject: [PATCH] work around gmock pthread dependency
+
+In meta-oe, gmock's .pc file does not declare that users of
+gmock must link against pthread. Let's work around that
+here by always linking tests against libpthread.
+
+Upstream-status: Inappropriate [embedded specific]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ test/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 25a70db..f490a24 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -130,6 +130,7 @@ ADD_EXECUTABLE(${TARGET_CYNARA_TESTS}
+ TARGET_LINK_LIBRARIES(${TARGET_CYNARA_TESTS}
+     ${PKGS_LDFLAGS}
+     ${PKGS_LIBRARIES}
++    pthread
+     crypt
+ )
+ INSTALL(TARGETS ${TARGET_CYNARA_TESTS} DESTINATION ${BIN_INSTALL_DIR})
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/cynara/cynara/run-ptest
+++ b/meta-security-framework/recipes-security/cynara/cynara/run-ptest
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cynara-tests | sed -e 's/^\[ *OK *\] \(\S*\)$/PASS: \1/' -e 's/^\[ *FAILED *\] \(\S*\)$/FAIL: \1/'
+sh /usr/bin/cynara-db-migration-tests | sed -e 's/^Test .*(\([^)]*\)).*passed.*/PASS: \1/' -e 's/^Test .*(\([^)]*\)).*failed.*/FAIL: \1/'

--- a/meta-security-framework/recipes-security/cynara/cynara_git.bb
+++ b/meta-security-framework/recipes-security/cynara/cynara_git.bb
@@ -10,4 +10,6 @@ file://systemd-stop-using-compat-libs.patch \
 file://systemd-configurable-unit-dir.patch \
 file://cynara-db-migration-abort-on-errors.patch \
 file://cynara-db-migration-sysroot-support.patch \
+file://PolicyKeyFeature-avoid-complex-global-constants.patch \
+file://globals-avoid-copying-other-globals.patch \
 "


### PR DESCRIPTION
If (and only if) PACKAGECONFIG includes "tests", the existing unit
tests get compiled and packaged as ptests. Otherwise there is no
cynara-ptest package because it would be empty.

With some fixes to the upstream source, all tests pass. These fixes
have been reported upstream.

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
