### PR TITLE
fix Cynara tests

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -37,11 +37,11 @@ SRC_URI_append = "${@bb.utils.contains('PACKAGECONFIG', 'tests', ' file://gmock-
 
 # Will be empty if no tests were built.
 inherit ptest
-FILES_${PN}-ptest += "${bindir}/cynara-tests ${bindir}/cynara-db-migration-tests ${localstatedir}/cynara/tests"
+FILES_${PN}-ptest += "${bindir}/cynara-tests ${bindir}/cynara-db-migration-tests ${datadir}/cynara/tests"
 do_install_ptest () {
     if ${@bb.utils.contains('PACKAGECONFIG', 'tests', 'true', 'false', d)}; then
-        mkdir -p ${D}/${localstatedir}/cynara/tests
-        cp -r ${S}/test/db/* ${D}/${localstatedir}/cynara/tests
+        mkdir -p ${D}/${datadir}/cynara/tests
+        cp -r ${S}/test/db/* ${D}/${datadir}/cynara/tests
     fi
 }
 

--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -48,7 +48,7 @@ do_install_ptest () {
 do_compile_prepend () {
     # en_US.UTF8 is not available, causing cynara-tests parser.getKeyAndValue to fail.
     # Submitted upstream: https://github.com/Samsung/cynara/issues/10
-    sed -i -e 's/std::locale("en_US.UTF8")/std::locale("C")/g' ${S}/test/credsCommons/parser/Parser.cpp
+    sed -i -e 's/std::locale("en_US.UTF8")/std::locale::classic()/g' ${S}/test/credsCommons/parser/Parser.cpp
 }
 
 inherit useradd


### PR DESCRIPTION
Upstream had a suggestion for improving the testing fix around the en_US locale. But more importantly, the DB tests did not actually work as specified in the recipe because of the wrong path. I hadn't noticed because I was only testing with a manually updated image, instead of using the final Cynara package.
