### PR TITLE
Cynara + D-Bus + security-manager-policy

### DIFF
--- a/meta-security-framework/README.md
+++ b/meta-security-framework/README.md
@@ -61,6 +61,16 @@ other layers needed. e.g.:
     /path/to/yocto/meta-intel-iot-security/meta-security-framework \
     "
 
+The Cynara-aware D-Bus daemon needs to be enabled explicitly by adding
+"dbus-cynara" to DISTRO_FEATURES, to allow using the layer without
+also changing the D-Bus behavior. When enabled, the regular "dbus"
+package gets replaced with an empty one that pulls in a separate
+"dbus-cynara" package automatically.
+
+The necessary Cyanara rules granting "System" and "User" process the
+http://tizen.org/privilege/internal/dbus privilege can be created
+by installing the "security-manager-policy" package.
+
 
 II. Misc
 ========

--- a/meta-security-framework/recipes-core/dbus/dbus-cynara_1.8.10.bb
+++ b/meta-security-framework/recipes-core/dbus/dbus-cynara_1.8.10.bb
@@ -1,0 +1,57 @@
+require recipes-core/dbus/dbus.inc
+FILESEXTRAPATHS_prepend := "${COREBASE}/meta/recipes-core/dbus/dbus:${THISDIR}/dbus:"
+S = "${WORKDIR}/dbus-${PV}"
+libexecdir = "${libdir}/dbus"
+
+SRC_URI[md5sum] = "6be5ef99ae784de9d04589eb067fe038"
+SRC_URI[sha256sum] = "10bf87fdb68815edd01d53885101dbcdd80dacad7198912cca61a4fa22dfaf8e"
+
+# From https://review.tizen.org/gerrit/#/admin/projects/platform/upstream/dbus
+# revision 9e77cdf01b73de313b360290ca0987410e04c082
+# aka https://review.tizen.org/gerrit/#/c/31310/
+#
+# Rebased onto 1.8.10 because that is the version in OE Fido.
+# Should coordinate (and redo) rebasing with the Samsung maintainers of the
+# D-Bus Cynara patches, see https://bugs.tizen.org/jira/browse/TC-2520
+SRC_URI += " \
+file://0001-Enable-checking-of-smack-context-from-DBus-interface.patch \
+file://0002-Enforce-smack-policy-from-conf-file.patch \
+file://0003-Set-error-when-message-delivery-is-denied-due-to-rec.patch \
+file://0004-GetConnectionCredentials-add-smack-support.patch \
+file://0005-policy-add-check-element.patch \
+file://0006-Integration-of-asynchronous-security-checks.patch \
+file://0007-Disable-message-dispatching-when-send-rule-result-is.patch \
+file://0008-Handle-receive-rule-result-unavailability-and-messag.patch \
+file://0009-Add-check-own-.-support.patch \
+file://0010-Fix-several-BusResult-dbus_bool_t-mismatches.patch \
+file://0011-Do-not-rely-on-Cynara-cache-when-processing-check-ru.patch \
+file://0013-various-compile-fixes.patch \
+"
+
+# Depends on special Cynara rules which get installed in the
+# security-manager-policy package.
+SRC_URI += "file://0012-Perform-Cynara-runtime-policy-checks-by-default.patch"
+
+DEPENDS += "cynara smack"
+EXTRA_OECONF += "--enable-cynara --enable-smack"
+
+# Only the main package gets created here, everything else remains in the
+# normal dbus recipe.
+do_install_append () {
+    for i in ${@' '.join([d.getVar('D', True) + x for x in (' '.join([d.getVar('FILES_dbus-cynara-' + p, True) or '' for p in ['lib', 'dev', 'staticdev', 'doc', 'locale', 'ptest']])).split()])}; do
+        rm -rf $i
+    done
+
+    # Try to remove empty directories, starting with the
+    # longest path (= deepest directory) first.
+    # Find needs a valid current directory. Somehow the directory
+    # we get called in is gone by the time that we get invoked.
+    ( cd ${D}
+      for i in `find . -type d | sort -r`; do
+        rmdir $i || true
+      done
+    )
+}
+
+# Avoid warning about dbus and dbus-cynara providing dbus-x11.
+RPROVIDES_${PN}_remove = "${OLDPKGNAME}"

--- a/meta-security-framework/recipes-core/dbus/dbus/0001-Enable-checking-of-smack-context-from-DBus-interface.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0001-Enable-checking-of-smack-context-from-DBus-interface.patch
@@ -1,0 +1,333 @@
+From a2a3e522e196d02baf1191d99dfc87fb0e4aeee9 Mon Sep 17 00:00:00 2001
+From: Brian McGillion <brian.mcgillion@intel.com>
+Date: Mon, 6 Feb 2012 18:46:05 +0200
+Subject: [PATCH 01/13] Enable checking of smack context from DBus interface
+
+Conflicts:
+	bus/driver.c
+	cmake/CMakeLists.txt
+
+Change-Id: Ibc9d1ccb86c3b28d8df3a4becf33ba30234832d8
+---
+ bus/Makefile.am          |   4 ++
+ bus/driver.c             |   5 ++
+ bus/smack.c              | 132 +++++++++++++++++++++++++++++++++++++++++++++++
+ bus/smack.h              |  36 +++++++++++++
+ cmake/CMakeLists.txt     |   3 ++
+ cmake/bus/CMakeLists.txt |   4 +-
+ configure.ac             |  15 ++++++
+ 7 files changed, 198 insertions(+), 1 deletion(-)
+ create mode 100644 bus/smack.c
+ create mode 100644 bus/smack.h
+
+diff --git a/bus/Makefile.am b/bus/Makefile.am
+index f335e30..26ec6d4 100644
+--- a/bus/Makefile.am
++++ b/bus/Makefile.am
+@@ -7,6 +7,7 @@ DBUS_BUS_LIBS = \
+ 	$(THREAD_LIBS) \
+ 	$(ADT_LIBS) \
+ 	$(NETWORK_libs) \
++	$(LIBSMACK_LIBS) \
+ 	$(NULL)
+ 
+ DBUS_LAUNCHER_LIBS = \
+@@ -21,6 +22,7 @@ AM_CPPFLAGS = \
+ 	-DDBUS_SYSTEM_CONFIG_FILE=\""$(configdir)/system.conf"\" \
+ 	-DDBUS_COMPILATION \
+ 	-DDBUS_STATIC_BUILD \
++	$(LIBSMACK_CFLAGS) \
+ 	$(NULL)
+ 
+ # if assertions are enabled, improve backtraces
+@@ -84,6 +86,8 @@ BUS_SOURCES=					\
+ 	services.h				\
+ 	signals.c				\
+ 	signals.h				\
++	smack.c                                 \
++	smack.h                                 \
+ 	stats.c					\
+ 	stats.h					\
+ 	test.c					\
+diff --git a/bus/driver.c b/bus/driver.c
+index e95a79d..fac614e 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -30,6 +30,7 @@
+ #include "services.h"
+ #include "selinux.h"
+ #include "signals.h"
++#include "smack.h"
+ #include "stats.h"
+ #include "utils.h"
+ 
+@@ -1774,6 +1775,10 @@ static const MessageHandler dbus_message_handlers[] = {
+     bus_driver_handle_get_id },
+   { "GetConnectionCredentials", "s", "a{sv}",
+     bus_driver_handle_get_connection_credentials },
++  { "GetConnectionSmackContext",
++    DBUS_TYPE_STRING_AS_STRING,
++    DBUS_TYPE_STRING_AS_STRING,
++    bus_smack_handle_get_connection_context },
+   { NULL, NULL, NULL, NULL }
+ };
+ 
+diff --git a/bus/smack.c b/bus/smack.c
+new file mode 100644
+index 0000000..b8542c2
+--- /dev/null
++++ b/bus/smack.c
+@@ -0,0 +1,132 @@
++/* smack.c - Provide interface to query smack context
++ *
++ * Author: Brian McGillion <brian.mcgillion@intel.com>
++ * Copyright © 2011 Intel Corporation
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
++ * 02110-1301 USA
++ */
++
++#include <config.h>
++#include "smack.h"
++
++#include <dbus/dbus-internals.h>
++
++#include "connection.h"
++#include "services.h"
++#include "utils.h"
++
++#ifdef DBUS_ENABLE_SMACK
++#include <sys/smack.h>
++#endif
++
++#ifdef DBUS_ENABLE_SMACK
++static char *
++bus_smack_get_label (DBusConnection *connection)
++{
++  char *label;
++  int sock_fd;
++
++  if (!dbus_connection_get_socket(connection, &sock_fd))
++    return NULL;
++
++  if (smack_new_label_from_socket(sock_fd, &label) < 0)
++    return NULL;
++  return label;
++}
++#endif
++
++dbus_bool_t
++bus_smack_handle_get_connection_context (DBusConnection *connection,
++                                         BusTransaction *transaction,
++                                         DBusMessage    *message,
++                                         DBusError      *error)
++{
++#ifdef DBUS_ENABLE_SMACK
++  const char *remote_end = NULL;
++  BusRegistry *registry;
++  DBusString remote_end_str;
++  BusService *service;
++  DBusConnection *remote_connection;
++  DBusMessage *reply = NULL;
++  char *label;
++
++  _DBUS_ASSERT_ERROR_IS_CLEAR (error);
++
++  registry = bus_connection_get_registry (connection);
++
++  if (!dbus_message_get_args (message, error, DBUS_TYPE_STRING, &remote_end,
++                              DBUS_TYPE_INVALID))
++    return FALSE;
++
++  _dbus_verbose ("asked for label of connection %s\n", remote_end);
++
++  _dbus_string_init_const (&remote_end_str, remote_end);
++
++  service = bus_registry_lookup (registry, &remote_end_str);
++  if (service == NULL)
++    {
++      dbus_set_error (error, DBUS_ERROR_NAME_HAS_NO_OWNER,
++                      "Bus name '%s' has no owner", remote_end);
++      return FALSE;
++    }
++
++  remote_connection = bus_service_get_primary_owners_connection (service);
++  if (remote_connection == NULL)
++    goto oom;
++
++  reply = dbus_message_new_method_return (message);
++  if (reply == NULL)
++    goto oom;
++
++  label = bus_smack_get_label (remote_connection);
++  if (label == NULL)
++    {
++      dbus_set_error (error, DBUS_ERROR_FAILED,
++                      "Failed to get the socket fd of the connection",
++                      remote_end);
++      goto err;
++    }
++
++  if (!dbus_message_append_args (reply, DBUS_TYPE_STRING,
++                                 &label, DBUS_TYPE_INVALID))
++    goto oom;
++
++  if (!bus_transaction_send_from_driver (transaction, connection, reply))
++    goto oom;
++
++  dbus_message_unref (reply);
++  dbus_free(label);
++
++  return TRUE;
++
++oom:
++  BUS_SET_OOM (error);
++
++err:
++  if (reply != NULL)
++    dbus_message_unref (reply);
++
++  dbus_free(label);
++
++  return FALSE;
++#else
++  dbus_set_error (error, DBUS_ERROR_NOT_SUPPORTED,
++                  "SMACK support is not enabled");
++  return FALSE;
++#endif
++}
+diff --git a/bus/smack.h b/bus/smack.h
+new file mode 100644
+index 0000000..04a4a2a
+--- /dev/null
++++ b/bus/smack.h
+@@ -0,0 +1,36 @@
++/* smack.h - Provide interface to query smack context
++ *
++ * Author: Brian McGillion <brian.mcgillion@intel.com>
++ * Copyright © 2011 Intel Corporation
++ *
++ * Based on example from Stats interface
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
++ * 02110-1301 USA
++ */
++
++#ifndef SMACK_H
++#define SMACK_H
++
++#include "bus.h"
++
++dbus_bool_t bus_smack_handle_get_connection_context (DBusConnection *connection,
++                                                     BusTransaction *transaction,
++                                                     DBusMessage    *message,
++                                                     DBusError      *error);
++
++#endif // SMACK_H
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index c767c17..b62934b 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -111,6 +111,8 @@ if(WIN32)
+     set(FD_SETSIZE "8192" CACHE STRING "The maximum number of connections that can be handled at once")
+ endif()
+ 
++option (DBUS_ENABLE_SMACK "enable smack checks in the daemon" OFF)
++
+ find_package(EXPAT)
+ find_package(X11)
+ find_package(GLib2)
+@@ -552,6 +554,7 @@ message("        Building bus stats API:   ${DBUS_ENABLE_STATS}                "
+ message("        installing system libs:   ${DBUS_INSTALL_SYSTEM_LIBS}         ")
+ message("        Building inotify support: ${DBUS_BUS_ENABLE_INOTIFY}          ")
+ message("        Building kqueue support:  ${DBUS_BUS_ENABLE_KQUEUE}           ")
++message("        Building Smack support:   ${DBUS_ENABLE_SMACK}                ")
+ message("        Building Doxygen docs:    ${DBUS_ENABLE_DOXYGEN_DOCS}         ")
+ message("        Building XML docs:        ${DBUS_ENABLE_XML_DOCS}             ")
+ message("        Daemon executable name:   ${DBUS_DAEMON_NAME}")
+diff --git a/cmake/bus/CMakeLists.txt b/cmake/bus/CMakeLists.txt
+index f5b41cd..95cebb0 100644
+--- a/cmake/bus/CMakeLists.txt
++++ b/cmake/bus/CMakeLists.txt
+@@ -69,7 +69,9 @@ set (BUS_SOURCES
+ 	${BUS_DIR}/test.c					
+ 	${BUS_DIR}/test.h					
+ 	${BUS_DIR}/utils.c					
+-	${BUS_DIR}/utils.h					
++	${BUS_DIR}/utils.h
++	${BUS_DIR}/smack.c
++	${BUS_DIR}/smack.h
+ 	${XML_SOURCES}
+ 	${DIR_WATCH_SOURCE}
+ )
+diff --git a/configure.ac b/configure.ac
+index df32f23..5d8750c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -202,6 +202,9 @@ if test "x$enable_embedded_tests" = xyes; then
+       [Define to build test code into the library and binaries])
+ fi
+ 
++# call early to ensure availability
++PKG_PROG_PKG_CONFIG
++
+ # DBUS_ENABLE_MODULAR_TESTS controls tests that work based on public API.
+ # These use GTest, from GLib, because life's too short. They're enabled by
+ # default (unless you don't have GLib), because they don't bloat the library
+@@ -1741,6 +1744,17 @@ if test "x$enable_stats" = xyes; then
+     [Define to enable bus daemon usage statistics])
+ fi
+ 
++#enable smack label support
++AC_ARG_ENABLE([smack], [AS_HELP_STRING([--enable-smack], [enable SMACK security checks])], [], [enable_smack=no])
++if test "x$enable_smack" = xyes; then
++  PKG_CHECK_MODULES([LIBSMACK], [libsmack >= 1.0],
++     [AC_DEFINE([DBUS_ENABLE_SMACK], [1], [Define to enable SMACK security features])],
++     [AC_MSG_ERROR([libsmack is required to enable smack support])])
++fi
++
++AC_SUBST([LIBSMACK_CFLAGS])
++AC_SUBST([LIBSMACK_LIBS])
++
+ AC_CONFIG_FILES([
+ Doxyfile
+ dbus/versioninfo.rc
+@@ -1826,6 +1840,7 @@ echo "
+         Building checks:          ${enable_checks}
+         Building bus stats API:   ${enable_stats}
+         Building SELinux support: ${have_selinux}
++	Building SMACK support:   ${enable_smack}
+         Building inotify support: ${have_inotify}
+         Building kqueue support:  ${have_kqueue}
+         Building systemd support: ${have_systemd}
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0002-Enforce-smack-policy-from-conf-file.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0002-Enforce-smack-policy-from-conf-file.patch
@@ -1,0 +1,485 @@
+From c7cee35a405b6c87d9ab8d8c221f973a4e992e94 Mon Sep 17 00:00:00 2001
+From: Brian McGillion <brian.mcgillion@intel.com>
+Date: Mon, 6 Feb 2012 18:48:30 +0200
+Subject: [PATCH 02/13] Enforce smack policy from conf file
+
+---
+ bus/config-parser.c |  38 ++++++++++----
+ bus/policy.c        | 141 +++++++++++++++++++++++++++++++++++++++++++++++++---
+ bus/policy.h        |   3 ++
+ bus/smack.c         | 111 +++++++++++++++++++++++++++++++++++++++++
+ bus/smack.h         |   4 ++
+ 5 files changed, 278 insertions(+), 19 deletions(-)
+
+diff --git a/bus/config-parser.c b/bus/config-parser.c
+index 7bc9c01..a86864a 100644
+--- a/bus/config-parser.c
++++ b/bus/config-parser.c
+@@ -44,6 +44,7 @@ typedef enum
+   POLICY_MANDATORY,
+   POLICY_USER,
+   POLICY_GROUP,
++  POLICY_SMACK,
+   POLICY_CONSOLE
+ } PolicyType;
+ 
+@@ -65,7 +66,11 @@ typedef struct
+     struct
+     {
+       PolicyType type;
+-      unsigned long gid_uid_or_at_console;      
++      union
++      {
++        unsigned long gid_uid_or_at_console;
++        char *smack_label;
++      };
+     } policy;
+ 
+     struct
+@@ -151,6 +156,8 @@ element_free (Element *e)
+ {
+   if (e->type == ELEMENT_LIMIT)
+     dbus_free (e->d.limit.name);
++  else if (e->type == ELEMENT_POLICY && e->d.policy.type == POLICY_SMACK)
++      dbus_free (e->d.policy.smack_label);
+   
+   dbus_free (e);
+ }
+@@ -988,6 +995,7 @@ start_busconfig_child (BusConfigParser   *parser,
+       const char *user;
+       const char *group;
+       const char *at_console;
++      const char *smack;
+ 
+       if ((e = push_element (parser, ELEMENT_POLICY)) == NULL)
+         {
+@@ -1004,20 +1012,16 @@ start_busconfig_child (BusConfigParser   *parser,
+                               "context", &context,
+                               "user", &user,
+                               "group", &group,
++                              "smack", &smack,
+                               "at_console", &at_console,
+                               NULL))
+         return FALSE;
+ 
+-      if (((context && user) ||
+-           (context && group) ||
+-           (context && at_console)) ||
+-           ((user && group) ||
+-           (user && at_console)) ||
+-           (group && at_console) ||
+-          !(context || user || group || at_console))
++      if (((context != NULL) + (user != NULL) + (group != NULL) +
++          (smack != NULL) + (at_console != NULL)) != 1)
+         {
+           dbus_set_error (error, DBUS_ERROR_FAILED,
+-                          "<policy> element must have exactly one of (context|user|group|at_console) attributes");
++                          "<policy> element must have exactly one of (context|user|group|smack|at_console) attributes");
+           return FALSE;
+         }
+ 
+@@ -1063,6 +1067,16 @@ start_busconfig_child (BusConfigParser   *parser,
+             _dbus_warn ("Unknown group \"%s\" in message bus configuration file\n",
+                         group);          
+         }
++      else if (smack != NULL)
++        {
++          e->d.policy.type = POLICY_SMACK;
++          e->d.policy.smack_label = _dbus_strdup (smack);
++          if (e->d.policy.smack_label == NULL)
++            {
++              BUS_SET_OOM (error);
++              return FALSE;
++            }
++        }
+       else if (at_console != NULL)
+         {
+            dbus_bool_t t;
+@@ -1647,8 +1661,10 @@ append_rule_from_element (BusConfigParser   *parser,
+                                              rule))
+             goto nomem;
+           break;
+-        
+-
++        case POLICY_SMACK:
++          if (!bus_policy_append_smack_rule (parser->policy, pe->d.policy.smack_label, rule))
++            goto nomem;
++          break;
+         case POLICY_CONSOLE:
+           if (!bus_policy_append_console_rule (parser->policy, pe->d.policy.gid_uid_or_at_console,
+                                                rule))
+diff --git a/bus/policy.c b/bus/policy.c
+index 082f385..567d3c1 100644
+--- a/bus/policy.c
++++ b/bus/policy.c
+@@ -26,6 +26,7 @@
+ #include "services.h"
+ #include "test.h"
+ #include "utils.h"
++#include "smack.h"
+ #include <dbus/dbus-list.h>
+ #include <dbus/dbus-hash.h>
+ #include <dbus/dbus-internals.h>
+@@ -126,12 +127,13 @@ struct BusPolicy
+ {
+   int refcount;
+ 
+-  DBusList *default_rules;         /**< Default policy rules */
+-  DBusList *mandatory_rules;       /**< Mandatory policy rules */
+-  DBusHashTable *rules_by_uid;     /**< per-UID policy rules */
+-  DBusHashTable *rules_by_gid;     /**< per-GID policy rules */
+-  DBusList *at_console_true_rules; /**< console user policy rules where at_console="true"*/
+-  DBusList *at_console_false_rules; /**< console user policy rules where at_console="false"*/
++  DBusList *default_rules;             /**< Default policy rules */
++  DBusList *mandatory_rules;           /**< Mandatory policy rules */
++  DBusHashTable *rules_by_uid;         /**< per-UID policy rules */
++  DBusHashTable *rules_by_gid;         /**< per-GID policy rules */
++  DBusHashTable *rules_by_smack_label; /**< per-SMACK label policy rules */
++  DBusList *at_console_true_rules;     /**< console user policy rules where at_console="true"*/
++  DBusList *at_console_false_rules;    /**< console user policy rules where at_console="false"*/
+ };
+ 
+ static void
+@@ -181,6 +183,14 @@ bus_policy_new (void)
+   if (policy->rules_by_gid == NULL)
+     goto failed;
+ 
++#ifdef DBUS_ENABLE_SMACK
++  policy->rules_by_smack_label = _dbus_hash_table_new (DBUS_HASH_STRING,
++                                                       (DBusFreeFunction) dbus_free,
++                                                       free_rule_list_func);
++  if (policy->rules_by_smack_label == NULL)
++    goto failed;
++#endif
++
+   return policy;
+   
+  failed:
+@@ -230,7 +240,13 @@ bus_policy_unref (BusPolicy *policy)
+           _dbus_hash_table_unref (policy->rules_by_gid);
+           policy->rules_by_gid = NULL;
+         }
+-      
++
++      if (policy->rules_by_smack_label)
++        {
++          _dbus_hash_table_unref (policy->rules_by_smack_label);
++          policy->rules_by_smack_label = NULL;
++        }
++
+       dbus_free (policy);
+     }
+ }
+@@ -356,6 +372,24 @@ bus_policy_create_client_policy (BusPolicy      *policy,
+         }
+     }
+ 
++  if (policy->rules_by_smack_label &&
++      _dbus_hash_table_get_n_entries (policy->rules_by_smack_label) > 0)
++    {
++      DBusList **list;
++      dbus_bool_t nomem_err = FALSE;
++
++      list = bus_smack_generate_allowed_list(connection, policy->rules_by_smack_label, &nomem_err);
++
++      if (list != NULL)
++        {
++          nomem_err = !add_list_to_client (list, client);
++          _dbus_list_clear (list);
++        }
++
++      if (nomem_err)
++        goto nomem;
++    }
++
+   if (!add_list_to_client (&policy->mandatory_rules,
+                            client))
+     goto nomem;
+@@ -576,6 +610,66 @@ bus_policy_append_group_rule (BusPolicy      *policy,
+   return TRUE;
+ }
+ 
++#ifdef DBUS_ENABLE_SMACK
++static DBusList **
++get_list_string (DBusHashTable *table,
++                 const char *key)
++{
++  DBusList **list;
++
++  if (key == NULL)
++      return NULL;
++
++  list = _dbus_hash_table_lookup_string (table, key);
++
++  if (list == NULL)
++    {
++      char *new_key;
++
++      list = dbus_new0 (DBusList*, 1);
++      if (list == NULL)
++        return NULL;
++
++      new_key = _dbus_strdup (key);
++      if (new_key == NULL)
++        {
++          dbus_free (list);
++          return NULL;
++        }
++
++      if (!_dbus_hash_table_insert_string (table, new_key, list))
++        {
++          dbus_free (list);
++          dbus_free (new_key);
++          return NULL;
++        }
++    }
++
++  return list;
++}
++#endif
++
++dbus_bool_t
++bus_policy_append_smack_rule (BusPolicy      *policy,
++                              const char     *label,
++                              BusPolicyRule  *rule)
++{
++#ifdef DBUS_ENABLE_SMACK
++  DBusList **list;
++
++  list = get_list_string (policy->rules_by_smack_label, label);
++  if (list == NULL)
++    return FALSE;
++
++  if (!_dbus_list_append (list, rule))
++    return FALSE;
++
++  bus_policy_rule_ref (rule);
++#endif
++
++  return TRUE;
++}
++
+ dbus_bool_t
+ bus_policy_append_console_rule (BusPolicy      *policy,
+                                 dbus_bool_t     at_console,
+@@ -653,6 +747,31 @@ merge_id_hash (DBusHashTable *dest,
+   return TRUE;
+ }
+ 
++#ifdef DBUS_ENABLE_SMACK
++static dbus_bool_t
++merge_string_hash (DBusHashTable *dest,
++                   DBusHashTable *to_absorb)
++{
++  DBusHashIter iter;
++
++  _dbus_hash_iter_init (to_absorb, &iter);
++  while (_dbus_hash_iter_next (&iter))
++    {
++      const char *absorb_label = _dbus_hash_iter_get_string_key(&iter);
++      DBusList **list = _dbus_hash_iter_get_value (&iter);
++      DBusList **target = get_list_string (dest, absorb_label);
++
++      if (target == NULL)
++        return FALSE;
++
++      if (!append_copy_of_policy_list (target, list))
++        return FALSE;
++    }
++
++  return TRUE;
++}
++#endif
++
+ dbus_bool_t
+ bus_policy_merge (BusPolicy *policy,
+                   BusPolicy *to_absorb)
+@@ -685,6 +804,12 @@ bus_policy_merge (BusPolicy *policy,
+                       to_absorb->rules_by_gid))
+     return FALSE;
+ 
++#ifdef DBUS_ENABLE_SMACK
++  if (!merge_string_hash (policy->rules_by_smack_label,
++                          to_absorb->rules_by_smack_label))
++    return FALSE;
++#endif
++
+   return TRUE;
+ }
+ 
+@@ -873,7 +998,7 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+ {
+   DBusList *link;
+   dbus_bool_t allowed;
+-  
++
+   /* policy->rules is in the order the rules appeared
+    * in the config file, i.e. last rule that applies wins
+    */
+diff --git a/bus/policy.h b/bus/policy.h
+index d1d3e72..effa2c6 100644
+--- a/bus/policy.h
++++ b/bus/policy.h
+@@ -130,6 +130,9 @@ dbus_bool_t      bus_policy_append_user_rule      (BusPolicy        *policy,
+ dbus_bool_t      bus_policy_append_group_rule     (BusPolicy        *policy,
+                                                    dbus_gid_t        gid,
+                                                    BusPolicyRule    *rule);
++dbus_bool_t      bus_policy_append_smack_rule     (BusPolicy        *policy,
++                                                   const char       *label,
++                                                   BusPolicyRule    *rule);
+ dbus_bool_t      bus_policy_append_console_rule   (BusPolicy        *policy,
+                                                    dbus_bool_t        at_console,
+                                                    BusPolicyRule    *rule);
+diff --git a/bus/smack.c b/bus/smack.c
+index b8542c2..d4546a3 100644
+--- a/bus/smack.c
++++ b/bus/smack.c
+@@ -29,11 +29,17 @@
+ #include "connection.h"
+ #include "services.h"
+ #include "utils.h"
++#include "policy.h"
+ 
+ #ifdef DBUS_ENABLE_SMACK
+ #include <sys/smack.h>
+ #endif
+ 
++#define SMACK_WRITE "W"
++#define SMACK_READ "R"
++#define SMACK_READ_WRITE "RW"
++
++
+ #ifdef DBUS_ENABLE_SMACK
+ static char *
+ bus_smack_get_label (DBusConnection *connection)
+@@ -130,3 +136,108 @@ err:
+   return FALSE;
+ #endif
+ }
++
++#ifdef DBUS_ENABLE_SMACK
++static dbus_bool_t
++bus_smack_has_access (const char *subject, const char *object,
++                      const char *access)
++{
++  return (smack_have_access (subject, object, access) == 1 ? TRUE : FALSE);
++}
++#endif
++
++
++/**
++ * Calculate the list of rules that apply to a connection.
++ *
++ * @param connection The inbound conenction
++ * @param rules_by_smack_label The table of object labels -> rules mapping
++ * @param nomem_err (out) If a nomem situation is encountered this value is set to TRUE.
++ * @returns the list of permitted rules if it exists and no errors were encountered otherwise NULL.
++ */
++DBusList**
++bus_smack_generate_allowed_list (DBusConnection *connection,
++                                 DBusHashTable  *rules_by_smack_label,
++                                 dbus_bool_t *nomem_err)
++{
++#ifdef DBUS_ENABLE_SMACK
++  char *subject_label;
++  DBusHashIter iter;
++  dbus_bool_t is_allowed;
++  DBusList **allowed_list;
++
++  /* the label of the subject, is the label on the new connection,
++     either the service itself or one of its clients */
++  subject_label = bus_smack_get_label (connection);
++  if (subject_label == NULL)
++    return NULL;
++
++  allowed_list = dbus_new0 (DBusList*, 1);
++  if (allowed_list == NULL)
++    goto nomem;
++
++  /* Iterate over all the smack labels we have parsed from the .conf files */
++  _dbus_hash_iter_init (rules_by_smack_label, &iter);
++  while (_dbus_hash_iter_next (&iter))
++    {
++      DBusList *link;
++      const char *object_label = _dbus_hash_iter_get_string_key (&iter);
++      /* the list here is all the rules that are 'protected'
++         by the SMACK label named $object_label */
++      DBusList **list = _dbus_hash_iter_get_value (&iter);
++
++      link = _dbus_list_get_first_link (list);
++      while (link != NULL)
++        {
++          BusPolicyRule *rule = link->data;
++          link = _dbus_list_get_next_link (list, link);
++          is_allowed = FALSE;
++
++          switch (rule->type)
++            {
++            case BUS_POLICY_RULE_OWN:
++              is_allowed = bus_smack_has_access (subject_label,
++                                                 object_label,
++                                                 SMACK_READ_WRITE);
++              break;
++            case BUS_POLICY_RULE_SEND:
++              is_allowed = bus_smack_has_access (subject_label,
++                                                 object_label,
++                                                 SMACK_WRITE);
++              break;
++            case BUS_POLICY_RULE_RECEIVE:
++              is_allowed = bus_smack_has_access (subject_label,
++                                                 object_label,
++                                                 SMACK_READ);
++              break;
++            default:
++              continue;
++            }
++
++          if (is_allowed)
++            {
++              if (!_dbus_list_append (allowed_list, rule))
++                goto nomem;
++
++              bus_policy_rule_ref (rule);
++            }
++
++          _dbus_verbose ("permission request subject (%s) -> object (%s) : %s", subject_label, object_label, (is_allowed ? "GRANTED" : "REJECTED"));
++        }
++    }
++
++  dbus_free(subject_label);
++  return allowed_list;
++
++nomem:
++  if (allowed_list != NULL)
++    _dbus_list_clear (allowed_list);
++
++  dbus_free(subject_label);
++  *nomem_err = TRUE;
++  return NULL;
++
++#else
++  return NULL;
++#endif
++}
+diff --git a/bus/smack.h b/bus/smack.h
+index 04a4a2a..6b1dfad 100644
+--- a/bus/smack.h
++++ b/bus/smack.h
+@@ -27,10 +27,14 @@
+ #define SMACK_H
+ 
+ #include "bus.h"
++#include <dbus/dbus-hash.h>
+ 
+ dbus_bool_t bus_smack_handle_get_connection_context (DBusConnection *connection,
+                                                      BusTransaction *transaction,
+                                                      DBusMessage    *message,
+                                                      DBusError      *error);
+ 
++DBusList **bus_smack_generate_allowed_list (DBusConnection *connection,
++                                            DBusHashTable *label_rules,
++                                            dbus_bool_t *error);
+ #endif // SMACK_H
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0003-Set-error-when-message-delivery-is-denied-due-to-rec.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0003-Set-error-when-message-delivery-is-denied-due-to-rec.patch
@@ -1,0 +1,37 @@
+From ee7f8d394ec4266198a264070b62b248b057712a Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Fri, 14 Nov 2014 18:39:38 +0000
+Subject: [PATCH 03/13] Set error when message delivery is denied due to
+ receive rule
+
+This makes bus_context_check_security_policy follow convention of
+setting errors if function indicates failure and has error parameter.
+Notable implication is that AccessDenied error will be sent if sending message
+to addressed recipient is denied due to receive rule. Previously, message
+was silently dropped.
+
+This also fixes assertion failure when message is denied at addressed recipient
+while sending pending auto activation messages.
+
+Bug: https://bugs.freedesktop.org/show_bug.cgi?id=86194
+Change-Id: Ib60b9b5cc2e64fe5c412534afb44f5d702b26b23
+---
+ bus/bus.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bus/bus.c b/bus/bus.c
+index 47cc345..f0d980e 100644
+--- a/bus/bus.c
++++ b/bus/bus.c
+@@ -1660,7 +1660,7 @@ bus_context_check_security_policy (BusContext     *context,
+       complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
+           "Rejected receive message", toggles,
+           message, sender, proposed_recipient, requested_reply,
+-          (addressed_recipient == proposed_recipient), NULL);
++          (addressed_recipient == proposed_recipient), error);
+       _dbus_verbose ("security policy disallowing message due to recipient policy\n");
+       return FALSE;
+     }
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0004-GetConnectionCredentials-add-smack-support.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0004-GetConnectionCredentials-add-smack-support.patch
@@ -1,0 +1,312 @@
+From a87ecb4477ba75cf1b95d84460c76400f81633fb Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Fri, 20 Jun 2014 16:55:00 +0200
+Subject: [PATCH 04/13] GetConnectionCredentials - add smack support
+
+A process should never change its Smack label while connected to
+D-Bus. If it did, we would end up with race conditions around
+permission checking. Therefore we can retrieve the Smack label once,
+when the process connects, and use that label whenever it is needed.
+
+A new public libdbus API also gets added: dbus_connection_get_smack_label()
+This is primarily for dbus-daemon, but may also be useful for other applications
+creating direct connections.
+
+Change-Id: I16ec50a031809aab879a543ec2d7effd56768bf1
+---
+ bus/Makefile.am            |  4 ++--
+ bus/driver.c               | 10 ++++++++++
+ bus/smack.c                | 32 +++++-------------------------
+ dbus/Makefile.am           |  5 +++--
+ dbus/dbus-connection.c     | 49 +++++++++++++++++++++++++++++++++++++++++++++-
+ dbus/dbus-connection.h     |  5 +++++
+ doc/dbus-specification.xml |  6 ++++++
+ 7 files changed, 79 insertions(+), 32 deletions(-)
+
+diff --git a/bus/Makefile.am b/bus/Makefile.am
+index 26ec6d4..a5c39d0 100644
+--- a/bus/Makefile.am
++++ b/bus/Makefile.am
+@@ -86,8 +86,8 @@ BUS_SOURCES=					\
+ 	services.h				\
+ 	signals.c				\
+ 	signals.h				\
+-	smack.c                                 \
+-	smack.h                                 \
++	smack.c					\
++	smack.h					\
+ 	stats.c					\
+ 	stats.h					\
+ 	test.c					\
+diff --git a/bus/driver.c b/bus/driver.c
+index fac614e..58f184c 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -1564,6 +1564,16 @@ bus_driver_handle_get_connection_credentials (DBusConnection *connection,
+         goto oom;
+     }
+ 
++#ifdef DBUS_ENABLE_SMACK
++  {
++    const char *smack_label;
++    if (dbus_connection_get_smack_label (conn, &smack_label)) {
++      if (!_dbus_asv_add_string (&array_iter, "SmackLabel", smack_label))
++        goto oom;
++    }
++  }
++#endif
++
+   if (!_dbus_asv_close (&reply_iter, &array_iter))
+     goto oom;
+ 
+diff --git a/bus/smack.c b/bus/smack.c
+index d4546a3..300d9da 100644
+--- a/bus/smack.c
++++ b/bus/smack.c
+@@ -40,22 +40,6 @@
+ #define SMACK_READ_WRITE "RW"
+ 
+ 
+-#ifdef DBUS_ENABLE_SMACK
+-static char *
+-bus_smack_get_label (DBusConnection *connection)
+-{
+-  char *label;
+-  int sock_fd;
+-
+-  if (!dbus_connection_get_socket(connection, &sock_fd))
+-    return NULL;
+-
+-  if (smack_new_label_from_socket(sock_fd, &label) < 0)
+-    return NULL;
+-  return label;
+-}
+-#endif
+-
+ dbus_bool_t
+ bus_smack_handle_get_connection_context (DBusConnection *connection,
+                                          BusTransaction *transaction,
+@@ -69,7 +53,7 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+   BusService *service;
+   DBusConnection *remote_connection;
+   DBusMessage *reply = NULL;
+-  char *label;
++  const char *label;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+ 
+@@ -99,8 +83,7 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+   if (reply == NULL)
+     goto oom;
+ 
+-  label = bus_smack_get_label (remote_connection);
+-  if (label == NULL)
++  if (!dbus_connection_get_smack_label(remote_connection, &label))
+     {
+       dbus_set_error (error, DBUS_ERROR_FAILED,
+                       "Failed to get the socket fd of the connection",
+@@ -116,7 +99,6 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+     goto oom;
+ 
+   dbus_message_unref (reply);
+-  dbus_free(label);
+ 
+   return TRUE;
+ 
+@@ -127,8 +109,6 @@ err:
+   if (reply != NULL)
+     dbus_message_unref (reply);
+ 
+-  dbus_free(label);
+-
+   return FALSE;
+ #else
+   dbus_set_error (error, DBUS_ERROR_NOT_SUPPORTED,
+@@ -161,15 +141,15 @@ bus_smack_generate_allowed_list (DBusConnection *connection,
+                                  dbus_bool_t *nomem_err)
+ {
+ #ifdef DBUS_ENABLE_SMACK
+-  char *subject_label;
++  const char *subject_label;
+   DBusHashIter iter;
+   dbus_bool_t is_allowed;
+   DBusList **allowed_list;
+ 
+   /* the label of the subject, is the label on the new connection,
+      either the service itself or one of its clients */
+-  subject_label = bus_smack_get_label (connection);
+-  if (subject_label == NULL)
++
++  if (!dbus_connection_get_smack_label(connection, &subject_label))
+     return NULL;
+ 
+   allowed_list = dbus_new0 (DBusList*, 1);
+@@ -226,14 +206,12 @@ bus_smack_generate_allowed_list (DBusConnection *connection,
+         }
+     }
+ 
+-  dbus_free(subject_label);
+   return allowed_list;
+ 
+ nomem:
+   if (allowed_list != NULL)
+     _dbus_list_clear (allowed_list);
+ 
+-  dbus_free(subject_label);
+   *nomem_err = TRUE;
+   return NULL;
+ 
+diff --git a/dbus/Makefile.am b/dbus/Makefile.am
+index b248107..86d5d46 100644
+--- a/dbus/Makefile.am
++++ b/dbus/Makefile.am
+@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
+ 	-I$(top_builddir) \
+ 	-I$(top_srcdir) \
+ 	$(SYSTEMD_CFLAGS) \
++	$(LIBSMACK_CFLAGS) \
+ 	$(VALGRIND_CFLAGS) \
+ 	-DDBUS_COMPILATION \
+ 	-DDBUS_MACHINE_UUID_FILE=\""$(localstatedir)/lib/dbus/machine-id"\" \
+@@ -283,7 +284,7 @@ libdbus_1_la_CPPFLAGS = \
+ 	$(AM_CPPFLAGS) \
+ 	-Ddbus_1_EXPORTS \
+ 	$(NULL)
+-libdbus_1_la_LIBADD= $(LIBDBUS_LIBS)
++libdbus_1_la_LIBADD= $(LIBDBUS_LIBS) $(LIBSMACK_LIBS)
+ libdbus_1_la_LDFLAGS = \
+ 	$(AM_LDFLAGS) \
+ 	$(export_symbols) \
+@@ -295,7 +296,7 @@ libdbus_internal_la_CPPFLAGS = \
+ 	$(AM_CPPFLAGS) \
+ 	-DDBUS_STATIC_BUILD \
+ 	$(NULL)
+-libdbus_internal_la_LIBADD=$(LIBDBUS_LIBS) $(SYSTEMD_LIBS)
++libdbus_internal_la_LIBADD=$(LIBDBUS_LIBS) $(SYSTEMD_LIBS) $(LIBSMACK_LIBS)
+ 
+ if DBUS_WIN
+ # This must be a separate convenience library, otherwise libtool notices
+diff --git a/dbus/dbus-connection.c b/dbus/dbus-connection.c
+index b574207..2b2b853 100644
+--- a/dbus/dbus-connection.c
++++ b/dbus/dbus-connection.c
+@@ -45,6 +45,11 @@
+ #include "dbus-bus.h"
+ #include "dbus-marshal-basic.h"
+ 
++#ifdef DBUS_ENABLE_SMACK
++#include <sys/smack.h>
++#include <stdlib.h>
++#endif
++
+ #ifdef DBUS_DISABLE_CHECKS
+ #define TOOK_LOCK_CHECK(connection)
+ #define RELEASING_LOCK_CHECK(connection)
+@@ -304,6 +309,9 @@ struct DBusConnection
+   DBusObjectTree *objects; /**< Object path handlers registered with this connection */
+ 
+   char *server_guid; /**< GUID of server if we are in shared_connections, #NULL if server GUID is unknown or connection is private */
++#ifdef DBUS_ENABLE_SMACK
++  char *peer_smack_label; /** Smack label of the peer at the time when the connection was established. Allocated with malloc(), NULL if unknown. */
++#endif
+ 
+   /* These two MUST be bools and not bitfields, because they are protected by a separate lock
+    * from connection->mutex and all bitfields in a word have to be read/written together.
+@@ -1285,6 +1293,19 @@ _dbus_connection_new_for_transport (DBusTransport *transport)
+   if (connection == NULL)
+     goto error;
+ 
++#ifdef DBUS_ENABLE_SMACK
++  /* If we cannot get the Smack label, proceed without. */
++  {
++    int sock_fd;
++    if (_dbus_transport_get_socket_fd(transport, &sock_fd)) {
++      char *label;
++      if (smack_new_label_from_socket(sock_fd, &label) >= 0) {
++        connection->peer_smack_label = label;
++      }
++    }
++  }
++#endif
++
+   _dbus_rmutex_new_at_location (&connection->mutex);
+   if (connection->mutex == NULL)
+     goto error;
+@@ -2790,7 +2811,12 @@ _dbus_connection_last_unref (DBusConnection *connection)
+   _dbus_rmutex_free_at_location (&connection->slot_mutex);
+ 
+   _dbus_rmutex_free_at_location (&connection->mutex);
+-  
++
++#ifdef DBUS_ENABLE_SMACK
++  if (connection->peer_smack_label)
++    free (connection->peer_smack_label);
++#endif
++
+   dbus_free (connection);
+ }
+ 
+@@ -5244,6 +5270,27 @@ dbus_connection_get_unix_process_id (DBusConnection *connection,
+   return result;
+ }
+ 
++#ifdef DBUS_ENABLE_SMACK
++/**
++ * Gets the Smack label of the peer at the time when the connection
++ * was established. Returns #TRUE if the label is filled in.
++ *
++ * @param connection the connection
++ * @param label return location for the Smack label; returned value is valid as long as the connection exists
++ * @returns #TRUE if uid is filled in with a valid process ID
++ */
++dbus_bool_t
++dbus_connection_get_smack_label (DBusConnection *connection,
++				 const char **label)
++{
++  _dbus_return_val_if_fail (connection != NULL, FALSE);
++  _dbus_return_val_if_fail (label != NULL, FALSE);
++
++  *label = connection->peer_smack_label;
++  return *label != NULL;
++}
++#endif
++
+ /**
+  * Gets the ADT audit data of the connection if any.
+  * Returns #TRUE if the structure pointer is returned.
+diff --git a/dbus/dbus-connection.h b/dbus/dbus-connection.h
+index fe4d04e..aac5704 100644
+--- a/dbus/dbus-connection.h
++++ b/dbus/dbus-connection.h
+@@ -264,6 +264,11 @@ dbus_bool_t        dbus_connection_get_unix_user                (DBusConnection
+ DBUS_EXPORT
+ dbus_bool_t        dbus_connection_get_unix_process_id          (DBusConnection             *connection,
+                                                                  unsigned long              *pid);
++#ifdef DBUS_ENABLE_SMACK
++DBUS_EXPORT
++dbus_bool_t        dbus_connection_get_smack_label              (DBusConnection             *connection,
++                                                                 const char                **label);
++#endif
+ DBUS_EXPORT
+ dbus_bool_t        dbus_connection_get_adt_audit_session_data   (DBusConnection             *connection,
+                                                                  void                      **data,
+diff --git a/doc/dbus-specification.xml b/doc/dbus-specification.xml
+index f6b0215..9f4a843 100644
+--- a/doc/dbus-specification.xml
++++ b/doc/dbus-specification.xml
+@@ -5829,6 +5829,12 @@
+                   this concept. On Unix, this is the process ID defined by
+                   POSIX.</entry>
+               </row>
++              <row>
++                <entry>SmackLabel</entry>
++                <entry>STRING</entry>
++                <entry>The Smack label of the process at the time when it connected
++                  to D-Bus, on platforms that have this concept.</entry>
++              </row>
+             </tbody>
+           </tgroup>
+         </informaltable>
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0005-policy-add-check-element.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0005-policy-add-check-element.patch
@@ -1,0 +1,629 @@
+From 55ed8c3f9eb889ba7a5f54bbf91bf31cd2893975 Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Wed, 30 Jul 2014 10:00:59 +0200
+Subject: [PATCH 05/13] policy: add <check> element
+
+The new <check> element is almost the same as <allow> and <deny>. The
+difference is that it has an additional "privilege" parameter which
+will be tested at runtime. Depending on the outcome of the check, the
+rule turns into an allow or deny rule.
+
+Executing these checks will be implemented separately. At the moment,
+a <check> is basically the same as <deny>.
+
+The representation of a rule grows by one additional pointer and needs
+one additional bit to represent <check> in addition to <allow>/<deny>.
+Reordering elements might mitigate this effect.
+
+Change-Id: I25baa802fdf41413a78200273c3a0b17ae7f1cfa
+---
+ bus/config-parser-common.c                         |  6 ++
+ bus/config-parser-common.h                         |  1 +
+ bus/config-parser.c                                | 71 +++++++++++++++++----
+ bus/policy.c                                       | 73 +++++++++++++---------
+ bus/policy.h                                       | 15 ++++-
+ configure.ac                                       |  1 +
+ test/Makefile.am                                   |  1 +
+ test/data/invalid-config-files/badcheck-1.conf     |  9 +++
+ test/data/invalid-config-files/badcheck-2.conf     |  9 +++
+ test/data/valid-config-files/check-1.conf          |  9 +++
+ .../valid-config-files/debug-check-some.conf.in    | 18 ++++++
+ 11 files changed, 168 insertions(+), 45 deletions(-)
+ create mode 100644 test/data/invalid-config-files/badcheck-1.conf
+ create mode 100644 test/data/invalid-config-files/badcheck-2.conf
+ create mode 100644 test/data/valid-config-files/check-1.conf
+ create mode 100644 test/data/valid-config-files/debug-check-some.conf.in
+
+diff --git a/bus/config-parser-common.c b/bus/config-parser-common.c
+index c522ff4..1cfe4c8 100644
+--- a/bus/config-parser-common.c
++++ b/bus/config-parser-common.c
+@@ -75,6 +75,10 @@ bus_config_parser_element_name_to_type (const char *name)
+     {
+       return ELEMENT_DENY;
+     }
++  else if (strcmp (name, "check") == 0)
++    {
++      return ELEMENT_CHECK;
++    }
+   else if (strcmp (name, "servicehelper") == 0)
+     {
+       return ELEMENT_SERVICEHELPER;
+@@ -155,6 +159,8 @@ bus_config_parser_element_type_to_name (ElementType type)
+       return "allow";
+     case ELEMENT_DENY:
+       return "deny";
++    case ELEMENT_CHECK:
++      return "check";
+     case ELEMENT_FORK:
+       return "fork";
+     case ELEMENT_PIDFILE:
+diff --git a/bus/config-parser-common.h b/bus/config-parser-common.h
+index 186bf4c..bff6fdb 100644
+--- a/bus/config-parser-common.h
++++ b/bus/config-parser-common.h
+@@ -36,6 +36,7 @@ typedef enum
+   ELEMENT_LIMIT,
+   ELEMENT_ALLOW,
+   ELEMENT_DENY,
++  ELEMENT_CHECK,
+   ELEMENT_FORK,
+   ELEMENT_PIDFILE,
+   ELEMENT_SERVICEDIR,
+diff --git a/bus/config-parser.c b/bus/config-parser.c
+index a86864a..79a62c9 100644
+--- a/bus/config-parser.c
++++ b/bus/config-parser.c
+@@ -1164,7 +1164,7 @@ append_rule_from_element (BusConfigParser   *parser,
+                           const char        *element_name,
+                           const char       **attribute_names,
+                           const char       **attribute_values,
+-                          dbus_bool_t        allow,
++                          BusPolicyRuleAccess access,
+                           DBusError         *error)
+ {
+   const char *log;
+@@ -1187,6 +1187,7 @@ append_rule_from_element (BusConfigParser   *parser,
+   const char *own_prefix;
+   const char *user;
+   const char *group;
++  const char *privilege;
+ 
+   BusPolicyRule *rule;
+   
+@@ -1214,6 +1215,7 @@ append_rule_from_element (BusConfigParser   *parser,
+                           "user", &user,
+                           "group", &group,
+                           "log", &log,
++                          "privilege", &privilege,
+                           NULL))
+     return FALSE;
+ 
+@@ -1222,6 +1224,7 @@ append_rule_from_element (BusConfigParser   *parser,
+         receive_interface || receive_member || receive_error || receive_sender ||
+         receive_type || receive_path || eavesdrop ||
+         send_requested_reply || receive_requested_reply ||
++        privilege ||
+         own || own_prefix || user || group))
+     {
+       dbus_set_error (error, DBUS_ERROR_FAILED,
+@@ -1238,7 +1241,30 @@ append_rule_from_element (BusConfigParser   *parser,
+                       element_name);
+       return FALSE;
+     }
+-  
++
++  if (access == BUS_POLICY_RULE_ACCESS_CHECK)
++    {
++      if (privilege == NULL || !*privilege)
++        {
++          dbus_set_error (error, DBUS_ERROR_FAILED,
++                          "On element <%s>, you must specify the privilege to be checked.",
++                          element_name);
++          return FALSE;
++        }
++    }
++  else
++    {
++      if (privilege != NULL && *privilege)
++        {
++          dbus_set_error (error, DBUS_ERROR_FAILED,
++                          "On element <%s>, privilege %s is used outside of a check rule.",
++                          element_name, privilege);
++          return FALSE;
++        }
++      else
++        privilege = NULL; /* replace (potentially) empty string with NULL pointer, it wouldn't be used anyway */
++    }
++
+   /* Allowed combinations of elements are:
+    *
+    *   base, must be all send or all receive:
+@@ -1412,7 +1438,7 @@ append_rule_from_element (BusConfigParser   *parser,
+           return FALSE;
+         }
+       
+-      rule = bus_policy_rule_new (BUS_POLICY_RULE_SEND, allow); 
++      rule = bus_policy_rule_new (BUS_POLICY_RULE_SEND, access);
+       if (rule == NULL)
+         goto nomem;
+       
+@@ -1494,7 +1520,7 @@ append_rule_from_element (BusConfigParser   *parser,
+           return FALSE;
+         }
+       
+-      rule = bus_policy_rule_new (BUS_POLICY_RULE_RECEIVE, allow); 
++      rule = bus_policy_rule_new (BUS_POLICY_RULE_RECEIVE, access);
+       if (rule == NULL)
+         goto nomem;
+ 
+@@ -1524,7 +1550,7 @@ append_rule_from_element (BusConfigParser   *parser,
+     }
+   else if (own || own_prefix)
+     {
+-      rule = bus_policy_rule_new (BUS_POLICY_RULE_OWN, allow); 
++      rule = bus_policy_rule_new (BUS_POLICY_RULE_OWN, access);
+       if (rule == NULL)
+         goto nomem;
+ 
+@@ -1550,7 +1576,7 @@ append_rule_from_element (BusConfigParser   *parser,
+     {      
+       if (IS_WILDCARD (user))
+         {
+-          rule = bus_policy_rule_new (BUS_POLICY_RULE_USER, allow); 
++          rule = bus_policy_rule_new (BUS_POLICY_RULE_USER, access);
+           if (rule == NULL)
+             goto nomem;
+ 
+@@ -1565,7 +1591,7 @@ append_rule_from_element (BusConfigParser   *parser,
+       
+           if (_dbus_parse_unix_user_from_config (&username, &uid))
+             {
+-              rule = bus_policy_rule_new (BUS_POLICY_RULE_USER, allow); 
++              rule = bus_policy_rule_new (BUS_POLICY_RULE_USER, access);
+               if (rule == NULL)
+                 goto nomem;
+ 
+@@ -1582,7 +1608,7 @@ append_rule_from_element (BusConfigParser   *parser,
+     {
+       if (IS_WILDCARD (group))
+         {
+-          rule = bus_policy_rule_new (BUS_POLICY_RULE_GROUP, allow); 
++          rule = bus_policy_rule_new (BUS_POLICY_RULE_GROUP, access);
+           if (rule == NULL)
+             goto nomem;
+ 
+@@ -1597,7 +1623,7 @@ append_rule_from_element (BusConfigParser   *parser,
+           
+           if (_dbus_parse_unix_group_from_config (&groupname, &gid))
+             {
+-              rule = bus_policy_rule_new (BUS_POLICY_RULE_GROUP, allow); 
++              rule = bus_policy_rule_new (BUS_POLICY_RULE_GROUP, access);
+               if (rule == NULL)
+                 goto nomem;
+ 
+@@ -1621,6 +1647,10 @@ append_rule_from_element (BusConfigParser   *parser,
+       _dbus_assert (pe != NULL);
+       _dbus_assert (pe->type == ELEMENT_POLICY);
+ 
++      rule->privilege = _dbus_strdup (privilege);
++      if (privilege && !rule->privilege)
++        goto nomem;
++
+       switch (pe->d.policy.type)
+         {
+         case POLICY_IGNORED:
+@@ -1697,7 +1727,7 @@ start_policy_child (BusConfigParser   *parser,
+     {
+       if (!append_rule_from_element (parser, element_name,
+                                      attribute_names, attribute_values,
+-                                     TRUE, error))
++                                     BUS_POLICY_RULE_ACCESS_ALLOW, error))
+         return FALSE;
+       
+       if (push_element (parser, ELEMENT_ALLOW) == NULL)
+@@ -1712,7 +1742,7 @@ start_policy_child (BusConfigParser   *parser,
+     {
+       if (!append_rule_from_element (parser, element_name,
+                                      attribute_names, attribute_values,
+-                                     FALSE, error))
++                                     BUS_POLICY_RULE_ACCESS_DENY, error))
+         return FALSE;
+       
+       if (push_element (parser, ELEMENT_DENY) == NULL)
+@@ -1723,6 +1753,21 @@ start_policy_child (BusConfigParser   *parser,
+       
+       return TRUE;
+     }
++  else if (strcmp (element_name, "check") == 0)
++    {
++      if (!append_rule_from_element (parser, element_name,
++                                     attribute_names, attribute_values,
++                                     BUS_POLICY_RULE_ACCESS_CHECK, error))
++        return FALSE;
++
++      if (push_element (parser, ELEMENT_CHECK) == NULL)
++        {
++          BUS_SET_OOM (error);
++          return FALSE;
++        }
++
++      return TRUE;
++    }
+   else
+     {
+       dbus_set_error (error, DBUS_ERROR_FAILED,
+@@ -2082,6 +2127,7 @@ bus_config_parser_end_element (BusConfigParser   *parser,
+     case ELEMENT_POLICY:
+     case ELEMENT_ALLOW:
+     case ELEMENT_DENY:
++    case ELEMENT_CHECK:
+     case ELEMENT_FORK:
+     case ELEMENT_SYSLOG:
+     case ELEMENT_KEEP_UMASK:
+@@ -2381,6 +2427,7 @@ bus_config_parser_content (BusConfigParser   *parser,
+     case ELEMENT_POLICY:
+     case ELEMENT_ALLOW:
+     case ELEMENT_DENY:
++    case ELEMENT_CHECK:
+     case ELEMENT_FORK:
+     case ELEMENT_SYSLOG:
+     case ELEMENT_KEEP_UMASK:
+@@ -2845,6 +2892,8 @@ do_load (const DBusString *full_path,
+   dbus_error_init (&error);
+ 
+   parser = bus_config_load (full_path, TRUE, NULL, &error);
++  if (dbus_error_is_set (&error))
++    _dbus_verbose ("Failed to load file: %s\n", error.message);
+   if (parser == NULL)
+     {
+       _DBUS_ASSERT_ERROR_IS_SET (&error);
+diff --git a/bus/policy.c b/bus/policy.c
+index 567d3c1..5af5b6b 100644
+--- a/bus/policy.c
++++ b/bus/policy.c
+@@ -33,7 +33,7 @@
+ 
+ BusPolicyRule*
+ bus_policy_rule_new (BusPolicyRuleType type,
+-                     dbus_bool_t       allow)
++                     BusPolicyRuleAccess access)
+ {
+   BusPolicyRule *rule;
+ 
+@@ -43,7 +43,7 @@ bus_policy_rule_new (BusPolicyRuleType type,
+ 
+   rule->type = type;
+   rule->refcount = 1;
+-  rule->allow = allow;
++  rule->access = access;
+ 
+   switch (rule->type)
+     {
+@@ -55,18 +55,19 @@ bus_policy_rule_new (BusPolicyRuleType type,
+       break;
+     case BUS_POLICY_RULE_SEND:
+       rule->d.send.message_type = DBUS_MESSAGE_TYPE_INVALID;
+-
+       /* allow rules default to TRUE (only requested replies allowed)
++       * check rules default to TRUE (only requested replies are checked)
+        * deny rules default to FALSE (only unrequested replies denied)
+        */
+-      rule->d.send.requested_reply = rule->allow;
++      rule->d.send.requested_reply = rule->access != BUS_POLICY_RULE_ACCESS_DENY;
+       break;
+     case BUS_POLICY_RULE_RECEIVE:
+       rule->d.receive.message_type = DBUS_MESSAGE_TYPE_INVALID;
+       /* allow rules default to TRUE (only requested replies allowed)
++       * check rules default to TRUE (only requested replies are checked)
+        * deny rules default to FALSE (only unrequested replies denied)
+        */
+-      rule->d.receive.requested_reply = rule->allow;
++      rule->d.receive.requested_reply = rule->access != BUS_POLICY_RULE_ACCESS_DENY;
+       break;
+     case BUS_POLICY_RULE_OWN:
+       break;
+@@ -118,7 +119,8 @@ bus_policy_rule_unref (BusPolicyRule *rule)
+         case BUS_POLICY_RULE_GROUP:
+           break;
+         }
+-      
++
++      dbus_free (rule->privilege);
+       dbus_free (rule);
+     }
+ }
+@@ -461,7 +463,10 @@ list_allows_user (dbus_bool_t           def,
+       else
+         continue;
+ 
+-      allowed = rule->allow;
++      /* We don't intend to support <check user="..." /> and <check group="..." />
++         rules. They are treated like deny.
++      */
++      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
+     }
+   
+   return allowed;
+@@ -1037,13 +1042,14 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+       /* If it's a reply, the requested_reply flag kicks in */
+       if (dbus_message_get_reply_serial (message) != 0)
+         {
+-          /* for allow, requested_reply=true means the rule applies
+-           * only when reply was requested. requested_reply=false means
+-           * always allow.
++          /* for allow or check requested_reply=true means the rule applies
++           * only when reply was requested. requested_reply=false means the
++           * rule always applies
+            */
+-          if (!requested_reply && rule->allow && rule->d.send.requested_reply && !rule->d.send.eavesdrop)
++          if (!requested_reply && rule->access != BUS_POLICY_RULE_ACCESS_DENY && rule->d.send.requested_reply && !rule->d.send.eavesdrop)
+             {
+-              _dbus_verbose ("  (policy) skipping allow rule since it only applies to requested replies and does not allow eavesdropping\n");
++              _dbus_verbose ("  (policy) skipping %s rule since it only applies to requested replies and does not allow eavesdropping\n",
++                  rule->access == BUS_POLICY_RULE_ACCESS_ALLOW ? "allow" : "check");
+               continue;
+             }
+ 
+@@ -1051,7 +1057,7 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+            * when the reply was not requested. requested_reply=true means the
+            * rule always applies.
+            */
+-          if (requested_reply && !rule->allow && !rule->d.send.requested_reply)
++          if (requested_reply && rule->access == BUS_POLICY_RULE_ACCESS_DENY && !rule->d.send.requested_reply)
+             {
+               _dbus_verbose ("  (policy) skipping deny rule since it only applies to unrequested replies\n");
+               continue;
+@@ -1074,13 +1080,15 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+           /* The interface is optional in messages. For allow rules, if the message
+            * has no interface we want to skip the rule (and thus not allow);
+            * for deny rules, if the message has no interface we want to use the
+-           * rule (and thus deny).
++           * rule (and thus deny). Check rules are meant to be used like allow
++           * rules (they can grant access, but not remove it), so we treat it like
++           * allow here.
+            */
+           dbus_bool_t no_interface;
+ 
+           no_interface = dbus_message_get_interface (message) == NULL;
+           
+-          if ((no_interface && rule->allow) ||
++          if ((no_interface && rule->access != BUS_POLICY_RULE_ACCESS_DENY) ||
+               (!no_interface && 
+                strcmp (dbus_message_get_interface (message),
+                        rule->d.send.interface) != 0))
+@@ -1154,7 +1162,7 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+         }
+ 
+       /* Use this rule */
+-      allowed = rule->allow;
++      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
+       *log = rule->d.send.log;
+       (*toggles)++;
+ 
+@@ -1216,19 +1224,21 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+             }
+         }
+ 
+-      /* for allow, eavesdrop=false means the rule doesn't apply when
+-       * eavesdropping. eavesdrop=true means always allow.
++
++      /* for allow or check, eavesdrop=false means the rule doesn't apply when
++       * eavesdropping. eavesdrop=true means the rule always applies
+        */
+-      if (eavesdropping && rule->allow && !rule->d.receive.eavesdrop)
++      if (eavesdropping && rule->access != BUS_POLICY_RULE_ACCESS_DENY && !rule->d.receive.eavesdrop)
+         {
+-          _dbus_verbose ("  (policy) skipping allow rule since it doesn't apply to eavesdropping\n");
++          _dbus_verbose ("  (policy) skipping %s rule since it doesn't apply to eavesdropping\n",
++              rule->access == BUS_POLICY_RULE_ACCESS_ALLOW ? "allow" : "check");
+           continue;
+         }
+ 
+       /* for deny, eavesdrop=true means the rule applies only when
+        * eavesdropping; eavesdrop=false means always deny.
+        */
+-      if (!eavesdropping && !rule->allow && rule->d.receive.eavesdrop)
++      if (!eavesdropping && rule->access == BUS_POLICY_RULE_ACCESS_DENY && rule->d.receive.eavesdrop)
+         {
+           _dbus_verbose ("  (policy) skipping deny rule since it only applies to eavesdropping\n");
+           continue;
+@@ -1237,13 +1247,14 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+       /* If it's a reply, the requested_reply flag kicks in */
+       if (dbus_message_get_reply_serial (message) != 0)
+         {
+-          /* for allow, requested_reply=true means the rule applies
+-           * only when reply was requested. requested_reply=false means
+-           * always allow.
++          /* for allow or check requested_reply=true means the rule applies
++           * only when reply was requested. requested_reply=false means the
++           * rule always applies
+            */
+-          if (!requested_reply && rule->allow && rule->d.receive.requested_reply && !rule->d.receive.eavesdrop)
++          if (!requested_reply && rule->access != BUS_POLICY_RULE_ACCESS_DENY && rule->d.send.requested_reply && !rule->d.send.eavesdrop)
+             {
+-              _dbus_verbose ("  (policy) skipping allow rule since it only applies to requested replies and does not allow eavesdropping\n");
++              _dbus_verbose ("  (policy) skipping %s rule since it only applies to requested replies and does not allow eavesdropping\n",
++                  rule->access == BUS_POLICY_RULE_ACCESS_DENY ? "allow" : "deny");
+               continue;
+             }
+ 
+@@ -1251,7 +1262,7 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+            * when the reply was not requested. requested_reply=true means the
+            * rule always applies.
+            */
+-          if (requested_reply && !rule->allow && !rule->d.receive.requested_reply)
++          if (requested_reply && rule->access == BUS_POLICY_RULE_ACCESS_DENY && !rule->d.receive.requested_reply)
+             {
+               _dbus_verbose ("  (policy) skipping deny rule since it only applies to unrequested replies\n");
+               continue;
+@@ -1274,13 +1285,13 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+           /* The interface is optional in messages. For allow rules, if the message
+            * has no interface we want to skip the rule (and thus not allow);
+            * for deny rules, if the message has no interface we want to use the
+-           * rule (and thus deny).
++           * rule (and thus deny). Check rules are treated like allow rules.
+            */
+           dbus_bool_t no_interface;
+ 
+           no_interface = dbus_message_get_interface (message) == NULL;
+           
+-          if ((no_interface && rule->allow) ||
++          if ((no_interface && rule->access != BUS_POLICY_RULE_ACCESS_DENY) ||
+               (!no_interface &&
+                strcmp (dbus_message_get_interface (message),
+                        rule->d.receive.interface) != 0))
+@@ -1355,7 +1366,7 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+         }
+       
+       /* Use this rule */
+-      allowed = rule->allow;
++      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
+       (*toggles)++;
+ 
+       _dbus_verbose ("  (policy) used rule, allow now = %d\n",
+@@ -1414,7 +1425,7 @@ bus_rules_check_can_own (DBusList *rules,
+         }
+ 
+       /* Use this rule */
+-      allowed = rule->allow;
++      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
+     }
+ 
+   return allowed;
+diff --git a/bus/policy.h b/bus/policy.h
+index effa2c6..fd66bcb 100644
+--- a/bus/policy.h
++++ b/bus/policy.h
+@@ -39,6 +39,14 @@ typedef enum
+   BUS_POLICY_RULE_GROUP
+ } BusPolicyRuleType;
+ 
++typedef enum
++{
++  BUS_POLICY_RULE_ACCESS_DENY,
++  BUS_POLICY_RULE_ACCESS_ALLOW,
++  /** runtime check resulting in allow or deny */
++  BUS_POLICY_RULE_ACCESS_CHECK
++} BusPolicyRuleAccess;
++
+ /** determines whether the rule affects a connection, or some global item */
+ #define BUS_POLICY_RULE_IS_PER_CLIENT(rule) (!((rule)->type == BUS_POLICY_RULE_USER || \
+                                                (rule)->type == BUS_POLICY_RULE_GROUP))
+@@ -49,8 +57,9 @@ struct BusPolicyRule
+   
+   BusPolicyRuleType type;
+ 
+-  unsigned int allow : 1; /**< #TRUE if this allows, #FALSE if it denies */
+-  
++  unsigned int access : 2; /**< BusPolicyRuleAccess */
++  char *privilege; /**< for BUS_POLICY_RULE_ACCESS_CHECK */
++
+   union
+   {
+     struct
+@@ -106,7 +115,7 @@ struct BusPolicyRule
+ };
+ 
+ BusPolicyRule* bus_policy_rule_new   (BusPolicyRuleType type,
+-                                      dbus_bool_t       allow);
++                                      BusPolicyRuleAccess access);
+ BusPolicyRule* bus_policy_rule_ref   (BusPolicyRule    *rule);
+ void           bus_policy_rule_unref (BusPolicyRule    *rule);
+ 
+diff --git a/configure.ac b/configure.ac
+index 5d8750c..c0ec075 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1785,6 +1785,7 @@ dbus-1.pc
+ dbus-1-uninstalled.pc
+ test/data/valid-config-files/debug-allow-all.conf
+ test/data/valid-config-files/debug-allow-all-sha1.conf
++test/data/valid-config-files/debug-check-some.conf
+ test/data/valid-config-files/incoming-limit.conf
+ test/data/valid-config-files-system/debug-allow-all-pass.conf
+ test/data/valid-config-files-system/debug-allow-all-fail.conf
+diff --git a/test/Makefile.am b/test/Makefile.am
+index cec5cda..1c7782e 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -249,6 +249,7 @@ in_data = \
+ 	data/valid-config-files-system/debug-allow-all-pass.conf.in \
+ 	data/valid-config-files/debug-allow-all-sha1.conf.in \
+ 	data/valid-config-files/debug-allow-all.conf.in \
++	data/valid-config-files/debug-check-some.conf.in \
+ 	data/valid-config-files/incoming-limit.conf.in \
+ 	data/invalid-service-files-system/org.freedesktop.DBus.TestSuiteNoExec.service.in \
+ 	data/invalid-service-files-system/org.freedesktop.DBus.TestSuiteNoService.service.in \
+diff --git a/test/data/invalid-config-files/badcheck-1.conf b/test/data/invalid-config-files/badcheck-1.conf
+new file mode 100644
+index 0000000..fad9f50
+--- /dev/null
++++ b/test/data/invalid-config-files/badcheck-1.conf
+@@ -0,0 +1,9 @@
++<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
++ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
++<busconfig>
++  <user>mybususer</user>
++  <listen>unix:path=/foo/bar</listen>
++  <policy context="default">
++    <allow privilege="foo" send_destination="*"/> <!-- extra privilege="foo" -->
++  </policy>
++</busconfig>
+diff --git a/test/data/invalid-config-files/badcheck-2.conf b/test/data/invalid-config-files/badcheck-2.conf
+new file mode 100644
+index 0000000..63c7ef2
+--- /dev/null
++++ b/test/data/invalid-config-files/badcheck-2.conf
+@@ -0,0 +1,9 @@
++<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
++ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
++<busconfig>
++  <user>mybususer</user>
++  <listen>unix:path=/foo/bar</listen>
++  <policy context="default">
++    <check send_destination="*"/> <!-- missing privilege="foo" -->
++  </policy>
++</busconfig>
+diff --git a/test/data/valid-config-files/check-1.conf b/test/data/valid-config-files/check-1.conf
+new file mode 100644
+index 0000000..ad71473
+--- /dev/null
++++ b/test/data/valid-config-files/check-1.conf
+@@ -0,0 +1,9 @@
++<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
++ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
++<busconfig>
++  <user>mybususer</user>
++  <listen>unix:path=/foo/bar</listen>
++  <policy context="default">
++    <check privilege="foo" send_destination="*"/>
++  </policy>
++</busconfig>
+diff --git a/test/data/valid-config-files/debug-check-some.conf.in b/test/data/valid-config-files/debug-check-some.conf.in
+new file mode 100644
+index 0000000..47ee854
+--- /dev/null
++++ b/test/data/valid-config-files/debug-check-some.conf.in
+@@ -0,0 +1,18 @@
++<!-- Bus that listens on a debug pipe and doesn't create any restrictions -->
++
++<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
++ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
++<busconfig>
++  <listen>debug-pipe:name=test-server</listen>
++  <listen>@TEST_LISTEN@</listen>
++  <servicedir>@DBUS_TEST_DATA@/valid-service-files</servicedir>
++  <policy context="default">
++    <allow send_interface="*"/>
++    <allow receive_interface="*"/>
++    <allow own="*"/>
++    <allow user="*"/>
++
++    <deny send_interface="org.freedesktop.TestSuite" send_member="Echo"/>
++    <check privilege="foo" send_interface="org.freedesktop.TestSuite" send_member="Echo"/>
++  </policy>
++</busconfig>
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0006-Integration-of-asynchronous-security-checks.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0006-Integration-of-asynchronous-security-checks.patch
@@ -1,0 +1,1641 @@
+From 517bea8558b9da69d17b1ee1c7f4d4d946837e33 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Thu, 27 Nov 2014 18:11:05 +0100
+Subject: [PATCH 06/13] Integration of asynchronous security checks
+
+This commit introduces basic framework for asynchronous policy
+checks and Cynara integration code. Functions for checking security
+policy can now return third value - BUS_RESULT_LATER denoting check
+result unavailability. Whenever policy checker cannot decide on the
+result of the check it is supposed to allocate DeferredMessage structure
+that will be passed to the upper layers which can decide what should be
+done in such situation.
+Proper handling of such case will be implemented in subsequent commits.
+Currently such return value results in message denial.
+
+Change-Id: I324b6ab68442e493853d8fe219c7a37fbd831872
+---
+ bus/Makefile.am  |   6 +
+ bus/bus.c        | 140 +++++++++++++++--------
+ bus/bus.h        |  61 ++++++----
+ bus/check.c      | 215 +++++++++++++++++++++++++++++++++++
+ bus/check.h      |  68 ++++++++++++
+ bus/connection.c |  60 ++++++++--
+ bus/connection.h |   5 +
+ bus/cynara.c     | 332 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ bus/cynara.h     |  37 +++++++
+ bus/dispatch.c   |  53 ++++++---
+ bus/policy.c     | 122 +++++++++++++++-----
+ bus/policy.h     |  36 +++---
+ configure.ac     |  12 ++
+ 13 files changed, 1009 insertions(+), 138 deletions(-)
+ create mode 100644 bus/check.c
+ create mode 100644 bus/check.h
+ create mode 100644 bus/cynara.c
+ create mode 100644 bus/cynara.h
+
+diff --git a/bus/Makefile.am b/bus/Makefile.am
+index a5c39d0..a0fea70 100644
+--- a/bus/Makefile.am
++++ b/bus/Makefile.am
+@@ -8,6 +8,7 @@ DBUS_BUS_LIBS = \
+ 	$(ADT_LIBS) \
+ 	$(NETWORK_libs) \
+ 	$(LIBSMACK_LIBS) \
++	$(CYNARA_LIBS) \
+ 	$(NULL)
+ 
+ DBUS_LAUNCHER_LIBS = \
+@@ -23,6 +24,7 @@ AM_CPPFLAGS = \
+ 	-DDBUS_COMPILATION \
+ 	-DDBUS_STATIC_BUILD \
+ 	$(LIBSMACK_CFLAGS) \
++	$(CYNARA_CFLAGS) \
+ 	$(NULL)
+ 
+ # if assertions are enabled, improve backtraces
+@@ -62,12 +64,16 @@ BUS_SOURCES=					\
+ 	activation-exit-codes.h			\
+ 	bus.c					\
+ 	bus.h					\
++	check.c					\
++	check.h					\
+ 	config-parser.c				\
+ 	config-parser.h				\
+ 	config-parser-common.c			\
+ 	config-parser-common.h			\
+ 	connection.c				\
+ 	connection.h				\
++	cynara.c				\
++	cynara.h				\
+ 	desktop-file.c				\
+ 	desktop-file.h				\
+ 	$(DIR_WATCH_SOURCE)			\
+diff --git a/bus/bus.c b/bus/bus.c
+index f0d980e..1fc9238 100644
+--- a/bus/bus.c
++++ b/bus/bus.c
+@@ -35,6 +35,7 @@
+ #include "signals.h"
+ #include "selinux.h"
+ #include "dir-watch.h"
++#include "check.h"
+ #include <dbus/dbus-list.h>
+ #include <dbus/dbus-hash.h>
+ #include <dbus/dbus-credentials.h>
+@@ -63,6 +64,7 @@ struct BusContext
+   BusRegistry *registry;
+   BusPolicy *policy;
+   BusMatchmaker *matchmaker;
++  BusCheck *check;
+   BusLimits limits;
+   DBusRLimit *initial_fd_limit;
+   unsigned int fork : 1;
+@@ -962,6 +964,10 @@ bus_context_new (const DBusString *config_file,
+ #endif
+     }
+ 
++  context->check = bus_check_new(context, error);
++  if (context->check == NULL)
++      goto failed;
++
+   dbus_server_free_data_slot (&server_data_slot);
+ 
+   return context;
+@@ -1086,6 +1092,12 @@ bus_context_unref (BusContext *context)
+ 
+       bus_context_shutdown (context);
+ 
++      if (context->check)
++        {
++          bus_check_unref(context->check);
++          context->check = NULL;
++        }
++
+       if (context->connections)
+         {
+           bus_connections_unref (context->connections);
+@@ -1215,6 +1227,12 @@ bus_context_get_loop (BusContext *context)
+   return context->loop;
+ }
+ 
++BusCheck*
++bus_context_get_check (BusContext *context)
++{
++  return context->check;
++}
++
+ dbus_bool_t
+ bus_context_allow_unix_user (BusContext   *context,
+                              unsigned long uid)
+@@ -1386,6 +1404,7 @@ complain_about_message (BusContext     *context,
+                         DBusConnection *proposed_recipient,
+                         dbus_bool_t     requested_reply,
+                         dbus_bool_t     log,
++                        const char     *privilege,
+                         DBusError      *error)
+ {
+   DBusError stack_error = DBUS_ERROR_INIT;
+@@ -1415,7 +1434,8 @@ complain_about_message (BusContext     *context,
+   dbus_set_error (&stack_error, error_name,
+       "%s, %d matched rules; type=\"%s\", sender=\"%s\" (%s) "
+       "interface=\"%s\" member=\"%s\" error name=\"%s\" "
+-      "requested_reply=\"%d\" destination=\"%s\" (%s)",
++      "requested_reply=\"%d\" destination=\"%s\" "
++      "privilege=\"%s\" (%s)",
+       complaint,
+       matched_rules,
+       dbus_message_type_to_string (dbus_message_get_type (message)),
+@@ -1426,6 +1446,7 @@ complain_about_message (BusContext     *context,
+       nonnull (dbus_message_get_error_name (message), "(unset)"),
+       requested_reply,
+       nonnull (dbus_message_get_destination (message), DBUS_SERVICE_DBUS),
++      nonnull (privilege, "(n/a)"),
+       proposed_recipient_loginfo);
+ 
+   /* If we hit OOM while setting the error, this will syslog "out of memory"
+@@ -1450,14 +1471,15 @@ complain_about_message (BusContext     *context,
+  * NULL for addressed_recipient may mean the bus driver, or may mean
+  * no destination was specified in the message (e.g. a signal).
+  */
+-dbus_bool_t
+-bus_context_check_security_policy (BusContext     *context,
+-                                   BusTransaction *transaction,
+-                                   DBusConnection *sender,
+-                                   DBusConnection *addressed_recipient,
+-                                   DBusConnection *proposed_recipient,
+-                                   DBusMessage    *message,
+-                                   DBusError      *error)
++BusResult
++bus_context_check_security_policy (BusContext          *context,
++                                   BusTransaction      *transaction,
++                                   DBusConnection      *sender,
++                                   DBusConnection      *addressed_recipient,
++                                   DBusConnection      *proposed_recipient,
++                                   DBusMessage         *message,
++                                   DBusError           *error,
++                                   BusDeferredMessage **deferred_message)
+ {
+   const char *dest;
+   BusClientPolicy *sender_policy;
+@@ -1466,6 +1488,7 @@ bus_context_check_security_policy (BusContext     *context,
+   dbus_bool_t log;
+   int type;
+   dbus_bool_t requested_reply;
++  const char *privilege;
+ 
+   type = dbus_message_get_type (message);
+   dest = dbus_message_get_destination (message);
+@@ -1493,7 +1516,7 @@ bus_context_check_security_policy (BusContext     *context,
+       dbus_set_error (error, DBUS_ERROR_ACCESS_DENIED,
+                       "Message bus will not accept messages of unknown type\n");
+ 
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   requested_reply = FALSE;
+@@ -1517,11 +1540,11 @@ bus_context_check_security_policy (BusContext     *context,
+               complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
+                   "An SELinux policy prevents this sender from sending this "
+                   "message to this recipient",
+-                  0, message, sender, proposed_recipient, FALSE, FALSE, error);
++                  0, message, sender, proposed_recipient, FALSE, FALSE, NULL, error);
+               _dbus_verbose ("SELinux security check denying send to service\n");
+             }
+ 
+-          return FALSE;
++          return BUS_RESULT_FALSE;
+         }
+ 
+       if (bus_connection_is_active (sender))
+@@ -1547,7 +1570,7 @@ bus_context_check_security_policy (BusContext     *context,
+                   if (dbus_error_is_set (&error2))
+                     {
+                       dbus_move_error (&error2, error);
+-                      return FALSE;
++                      return BUS_RESULT_FALSE;
+                     }
+                 }
+             }
+@@ -1564,7 +1587,7 @@ bus_context_check_security_policy (BusContext     *context,
+             {
+               _dbus_verbose ("security check allowing %s message\n",
+                              "Hello");
+-              return TRUE;
++              return BUS_RESULT_TRUE;
+             }
+           else
+             {
+@@ -1575,7 +1598,7 @@ bus_context_check_security_policy (BusContext     *context,
+                               "Client tried to send a message other than %s without being registered",
+                               "Hello");
+ 
+-              return FALSE;
++              return BUS_RESULT_FALSE;
+             }
+         }
+     }
+@@ -1624,20 +1647,32 @@ bus_context_check_security_policy (BusContext     *context,
+                 (proposed_recipient == NULL && recipient_policy == NULL));
+ 
+   log = FALSE;
+-  if (sender_policy &&
+-      !bus_client_policy_check_can_send (sender_policy,
+-                                         context->registry,
+-                                         requested_reply,
+-                                         proposed_recipient,
+-                                         message, &toggles, &log))
+-    {
+-      complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
+-          "Rejected send message", toggles,
+-          message, sender, proposed_recipient, requested_reply,
+-          (addressed_recipient == proposed_recipient), error);
+-      _dbus_verbose ("security policy disallowing message due to sender policy\n");
+-      return FALSE;
+-    }
++  if (sender_policy) {
++    switch (bus_client_policy_check_can_send (sender,
++                                              sender_policy,
++                                              context->registry,
++                                              requested_reply,
++                                              addressed_recipient,
++                                              proposed_recipient,
++                                              message, &toggles, &log, &privilege,
++                                              deferred_message))
++      {
++      case BUS_RESULT_TRUE:
++        break;
++      case BUS_RESULT_FALSE:
++        complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
++                                "Rejected send message", toggles,
++                                message, sender, proposed_recipient, requested_reply,
++                                (addressed_recipient == proposed_recipient), privilege,
++                                error);
++        _dbus_verbose ("security policy disallowing message due to sender policy\n");
++        return BUS_RESULT_FALSE;
++        break;
++      case BUS_RESULT_LATER:
++        return BUS_RESULT_LATER;
++        break;
++      }
++  }
+ 
+   if (log)
+     {
+@@ -1646,24 +1681,31 @@ bus_context_check_security_policy (BusContext     *context,
+       complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
+           "Would reject message", toggles,
+           message, sender, proposed_recipient, requested_reply,
+-          TRUE, NULL);
++          TRUE, privilege, NULL);
+     }
+ 
+-  if (recipient_policy &&
+-      !bus_client_policy_check_can_receive (recipient_policy,
+-                                            context->registry,
+-                                            requested_reply,
+-                                            sender,
+-                                            addressed_recipient, proposed_recipient,
+-                                            message, &toggles))
+-    {
+-      complain_about_message (context, DBUS_ERROR_ACCESS_DENIED,
+-          "Rejected receive message", toggles,
+-          message, sender, proposed_recipient, requested_reply,
+-          (addressed_recipient == proposed_recipient), error);
+-      _dbus_verbose ("security policy disallowing message due to recipient policy\n");
+-      return FALSE;
+-    }
++  if (recipient_policy) {
++      switch (bus_client_policy_check_can_receive (recipient_policy,
++                                                   context->registry,
++                                                   requested_reply,
++                                                   sender,
++                                                   addressed_recipient, proposed_recipient,
++                                                   message, &toggles, &privilege, deferred_message))
++      {
++      case BUS_RESULT_TRUE:
++        break;
++      case BUS_RESULT_FALSE:
++        complain_about_message(context, DBUS_ERROR_ACCESS_DENIED,
++            "Rejected receive message", toggles, message, sender,
++            proposed_recipient, requested_reply,
++            (addressed_recipient == proposed_recipient), privilege, error);
++        _dbus_verbose(
++            "security policy disallowing message due to recipient policy\n");
++        return BUS_RESULT_FALSE;
++      case BUS_RESULT_LATER:
++        return BUS_RESULT_LATER;
++      }
++  }
+ 
+   /* See if limits on size have been exceeded */
+   if (proposed_recipient &&
+@@ -1672,10 +1714,10 @@ bus_context_check_security_policy (BusContext     *context,
+     {
+       complain_about_message (context, DBUS_ERROR_LIMITS_EXCEEDED,
+           "Rejected: destination has a full message queue",
+-          0, message, sender, proposed_recipient, requested_reply, TRUE,
++          0, message, sender, proposed_recipient, requested_reply, TRUE, NULL,
+           error);
+       _dbus_verbose ("security policy disallowing message due to full message queue\n");
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   /* Record that we will allow a reply here in the future (don't
+@@ -1692,11 +1734,11 @@ bus_context_check_security_policy (BusContext     *context,
+                                      message, error))
+     {
+       _dbus_verbose ("Failed to record reply expectation or problem with the message expecting a reply\n");
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   _dbus_verbose ("security policy allowing message\n");
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ }
+ 
+ void
+diff --git a/bus/bus.h b/bus/bus.h
+index dac6ea5..040e3c7 100644
+--- a/bus/bus.h
++++ b/bus/bus.h
+@@ -30,19 +30,38 @@
+ #include <dbus/dbus-pipe.h>
+ #include <dbus/dbus-sysdeps.h>
+ 
+-typedef struct BusActivation    BusActivation;
+-typedef struct BusConnections   BusConnections;
+-typedef struct BusContext       BusContext;
+-typedef struct BusPolicy        BusPolicy;
+-typedef struct BusClientPolicy  BusClientPolicy;
+-typedef struct BusPolicyRule    BusPolicyRule;
+-typedef struct BusRegistry      BusRegistry;
+-typedef struct BusSELinuxID     BusSELinuxID;
+-typedef struct BusService       BusService;
+-typedef struct BusOwner		BusOwner;
+-typedef struct BusTransaction   BusTransaction;
+-typedef struct BusMatchmaker    BusMatchmaker;
+-typedef struct BusMatchRule     BusMatchRule;
++typedef struct BusActivation      BusActivation;
++typedef struct BusConnections     BusConnections;
++typedef struct BusContext         BusContext;
++typedef struct BusPolicy          BusPolicy;
++typedef struct BusClientPolicy    BusClientPolicy;
++typedef struct BusPolicyRule      BusPolicyRule;
++typedef struct BusRegistry        BusRegistry;
++typedef struct BusSELinuxID       BusSELinuxID;
++typedef struct BusService         BusService;
++typedef struct BusOwner           BusOwner;
++typedef struct BusTransaction     BusTransaction;
++typedef struct BusMatchmaker      BusMatchmaker;
++typedef struct BusMatchRule       BusMatchRule;
++typedef struct BusCheck           BusCheck;
++typedef struct BusDeferredMessage BusDeferredMessage;
++typedef struct BusCynara          BusCynara;
++
++/**
++ * This uses BUS_RESULT_TRUE = 0 != TRUE intentionally, to trigger
++ * runtime failures where code uses a simple boolean check or
++ * comparison with TRUE/FALSE or returns TRUE/FALSE when it should use
++ * one of these enums. Such broken code unfortunately does not trigger
++ * compile time errors in C.
++ */
++typedef enum {
++  /** operation allowed or succeeded */
++  BUS_RESULT_TRUE,
++  /** operation denied or failed */
++  BUS_RESULT_FALSE,
++  /** no result yet, ask again later */
++  BUS_RESULT_LATER
++} BusResult;
+ 
+ typedef struct
+ {
+@@ -96,6 +115,7 @@ BusConnections*   bus_context_get_connections                    (BusContext
+ BusActivation*    bus_context_get_activation                     (BusContext       *context);
+ BusMatchmaker*    bus_context_get_matchmaker                     (BusContext       *context);
+ DBusLoop*         bus_context_get_loop                           (BusContext       *context);
++BusCheck *        bus_context_get_check                          (BusContext       *context);
+ dbus_bool_t       bus_context_allow_unix_user                    (BusContext       *context,
+                                                                   unsigned long     uid);
+ dbus_bool_t       bus_context_allow_windows_user                 (BusContext       *context,
+@@ -121,13 +141,14 @@ void              bus_context_log                                (BusContext
+                                                                   DBusSystemLogSeverity severity,
+                                                                   const char       *msg,
+                                                                   ...);
+-dbus_bool_t       bus_context_check_security_policy              (BusContext       *context,
+-                                                                  BusTransaction   *transaction,
+-                                                                  DBusConnection   *sender,
+-                                                                  DBusConnection   *addressed_recipient,
+-                                                                  DBusConnection   *proposed_recipient,
+-                                                                  DBusMessage      *message,
+-                                                                  DBusError        *error);
++BusResult         bus_context_check_security_policy              (BusContext          *context,
++                                                                  BusTransaction      *transaction,
++                                                                  DBusConnection      *sender,
++                                                                  DBusConnection      *addressed_recipient,
++                                                                  DBusConnection      *proposed_recipient,
++                                                                  DBusMessage         *message,
++                                                                  DBusError           *error,
++                                                                  BusDeferredMessage **deferred_message);
+ void              bus_context_check_all_watches                  (BusContext       *context);
+ 
+ #endif /* BUS_BUS_H */
+diff --git a/bus/check.c b/bus/check.c
+new file mode 100644
+index 0000000..d2f418a
+--- /dev/null
++++ b/bus/check.c
+@@ -0,0 +1,215 @@
++/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
++/* check.c  Bus security policy runtime check
++ *
++ * Copyright (C) 2014  Intel, Inc.
++ * Copyright (c) 2014  Samsung Electronics, Ltd.
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#include <config.h>
++#include "check.h"
++#include "connection.h"
++#include "dispatch.h"
++#include "cynara.h"
++#include "utils.h"
++#include <dbus/dbus-connection-internal.h>
++#include <dbus/dbus-message-internal.h>
++#include <dbus/dbus-internals.h>
++
++
++typedef struct BusCheck
++{
++  int refcount;
++
++  BusContext *context;
++  BusCynara *cynara;
++} BusCheck;
++
++typedef struct BusDeferredMessage
++{
++  int refcount;
++
++  DBusMessage *message;
++  DBusConnection *sender;
++  DBusConnection *proposed_recipient;
++  DBusConnection *addressed_recipient;
++  dbus_bool_t full_dispatch;
++  BusDeferredMessageStatus status;
++  BusResult response;
++  BusCheckResponseFunc response_callback;
++} BusDeferredMessage;
++
++BusCheck *
++bus_check_new (BusContext *context, DBusError *error)
++{
++  BusCheck *check;
++
++  check = dbus_new(BusCheck, 1);
++  if (check == NULL)
++    {
++      BUS_SET_OOM(error);
++      return NULL;
++    }
++
++  check->refcount = 1;
++  check->context = context;
++  check->cynara = bus_cynara_new(check, error);
++  if (dbus_error_is_set(error))
++    {
++      dbus_free(check);
++      return NULL;
++    }
++
++  return check;
++}
++
++BusCheck *
++bus_check_ref (BusCheck *check)
++{
++  _dbus_assert (check->refcount > 0);
++  check->refcount += 1;
++
++  return check;
++}
++
++void
++bus_check_unref (BusCheck *check)
++{
++  _dbus_assert (check->refcount > 0);
++
++  check->refcount -= 1;
++
++  if (check->refcount == 0)
++    {
++      bus_cynara_unref(check->cynara);
++      dbus_free(check);
++    }
++}
++
++BusContext *
++bus_check_get_context (BusCheck *check)
++{
++  return check->context;
++}
++
++BusCynara *
++bus_check_get_cynara (BusCheck *check)
++{
++  return check->cynara;
++}
++
++BusResult
++bus_check_privilege (BusCheck *check,
++                     DBusMessage *message,
++                     DBusConnection *sender,
++                     DBusConnection *addressed_recipient,
++                     DBusConnection *proposed_recipient,
++                     const char *privilege,
++                     BusDeferredMessageStatus check_type,
++                     BusDeferredMessage **deferred_message)
++{
++  BusResult result = BUS_RESULT_FALSE;
++  BusCynara *cynara;
++  DBusConnection *connection;
++
++  connection = check_type == BUS_DEFERRED_MESSAGE_CHECK_RECEIVE ? proposed_recipient : sender;
++
++  if (!dbus_connection_get_is_connected(connection))
++    {
++      return BUS_RESULT_FALSE;
++    }
++
++  /* ask policy checkers */
++#ifdef DBUS_ENABLE_CYNARA
++  cynara = bus_check_get_cynara(check);
++  result = bus_cynara_check_privilege(cynara, message, sender, addressed_recipient,
++      proposed_recipient, privilege, check_type, deferred_message);
++#endif
++
++  if (result == BUS_RESULT_LATER && deferred_message != NULL)
++    {
++      (*deferred_message)->status |= check_type;
++    }
++  return result;
++}
++
++BusDeferredMessage *bus_deferred_message_new (DBusMessage *message,
++                                              DBusConnection *sender,
++                                              DBusConnection *addressed_recipient,
++                                              DBusConnection *proposed_recipient,
++                                              BusResult response)
++{
++  BusDeferredMessage *deferred_message;
++
++  deferred_message = dbus_new(BusDeferredMessage, 1);
++  if (deferred_message == NULL)
++    {
++      return NULL;
++    }
++
++  deferred_message->refcount = 1;
++  deferred_message->sender = sender != NULL ? dbus_connection_ref(sender) : NULL;
++  deferred_message->addressed_recipient = addressed_recipient != NULL ? dbus_connection_ref(addressed_recipient) : NULL;
++  deferred_message->proposed_recipient = proposed_recipient != NULL ? dbus_connection_ref(proposed_recipient) : NULL;
++  deferred_message->message = dbus_message_ref(message);
++  deferred_message->response = response;
++  deferred_message->status = 0;
++  deferred_message->full_dispatch = FALSE;
++  deferred_message->response_callback = NULL;
++
++  return deferred_message;
++}
++
++BusDeferredMessage *
++bus_deferred_message_ref (BusDeferredMessage *deferred_message)
++{
++  _dbus_assert (deferred_message->refcount > 0);
++  deferred_message->refcount += 1;
++  return deferred_message;
++}
++
++void
++bus_deferred_message_unref (BusDeferredMessage *deferred_message)
++{
++  _dbus_assert (deferred_message->refcount > 0);
++
++  deferred_message->refcount -= 1;
++
++   if (deferred_message->refcount == 0)
++     {
++       dbus_message_unref(deferred_message->message);
++       if (deferred_message->sender != NULL)
++           dbus_connection_unref(deferred_message->sender);
++       if (deferred_message->addressed_recipient != NULL)
++           dbus_connection_unref(deferred_message->addressed_recipient);
++       if (deferred_message->proposed_recipient != NULL)
++           dbus_connection_unref(deferred_message->proposed_recipient);
++       dbus_free(deferred_message);
++     }
++}
++
++void
++bus_deferred_message_response_received (BusDeferredMessage *deferred_message,
++                                        BusResult result)
++{
++  if (deferred_message->response_callback != NULL)
++    {
++      deferred_message->response_callback(deferred_message, result);
++    }
++}
+diff --git a/bus/check.h b/bus/check.h
+new file mode 100644
+index 0000000..c3fcaf9
+--- /dev/null
++++ b/bus/check.h
+@@ -0,0 +1,68 @@
++/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
++/* check.h  Bus security policy runtime check
++ *
++ * Copyright (C) 2014  Intel, Inc.
++ * Copyright (c) 2014  Samsung Electronics, Ltd.
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifndef BUS_CHECK_H
++#define BUS_CHECK_H
++
++#include "bus.h"
++#include "policy.h"
++
++
++typedef void (*BusCheckResponseFunc) (BusDeferredMessage *message,
++                                      BusResult result);
++
++typedef enum {
++  BUS_DEFERRED_MESSAGE_CHECK_SEND      = 1 << 0,
++  BUS_DEFERRED_MESSAGE_CHECK_RECEIVE   = 1 << 1,
++  BUS_DEFERRED_MESSAGE_CHECK_OWN       = 1 << 2,
++} BusDeferredMessageStatus;
++
++
++BusCheck   *bus_check_new         (BusContext *context,
++                                   DBusError *error);
++BusCheck   *bus_check_ref         (BusCheck *check);
++void        bus_check_unref       (BusCheck *check);
++
++BusContext *bus_check_get_context (BusCheck *check);
++BusCynara  *bus_check_get_cynara  (BusCheck *check);
++BusResult   bus_check_privilege   (BusCheck *check,
++                                   DBusMessage *message,
++                                   DBusConnection *sender,
++                                   DBusConnection *addressed_recipient,
++                                   DBusConnection *proposed_recipient,
++                                   const char *privilege,
++                                   BusDeferredMessageStatus check_type,
++                                   BusDeferredMessage **deferred_message);
++
++BusDeferredMessage *bus_deferred_message_new                (DBusMessage *message,
++                                                             DBusConnection *sender,
++                                                             DBusConnection *addressed_recipient,
++                                                             DBusConnection *proposed_recipient,
++                                                             BusResult response);
++
++BusDeferredMessage *bus_deferred_message_ref                (BusDeferredMessage *deferred_message);
++void                bus_deferred_message_unref              (BusDeferredMessage *deferred_message);
++void                bus_deferred_message_response_received  (BusDeferredMessage *deferred_message,
++                                                             BusResult result);
++#endif /* BUS_CHECK_H */
+diff --git a/bus/connection.c b/bus/connection.c
+index 519122c..12d8147 100644
+--- a/bus/connection.c
++++ b/bus/connection.c
+@@ -34,6 +34,10 @@
+ #include <dbus/dbus-hash.h>
+ #include <dbus/dbus-timeout.h>
+ #include <dbus/dbus-connection-internal.h>
++#ifdef DBUS_ENABLE_CYNARA
++#include <stdlib.h>
++#include <cynara-session.h>
++#endif
+ 
+ /* Trim executed commands to this length; we want to keep logs readable */
+ #define MAX_LOG_COMMAND_LEN 50
+@@ -105,6 +109,9 @@ typedef struct
+ #endif
+   int n_pending_unix_fds;
+   DBusTimeout *pending_unix_fds_timeout;
++#ifdef DBUS_ENABLE_CYNARA
++  char *cynara_session_id;
++#endif
+ } BusConnectionData;
+ 
+ static dbus_bool_t bus_pending_reply_expired (BusExpireList *list,
+@@ -118,8 +125,8 @@ static dbus_bool_t expire_incomplete_timeout (void *data);
+ 
+ #define BUS_CONNECTION_DATA(connection) (dbus_connection_get_data ((connection), connection_data_slot))
+ 
+-static DBusLoop*
+-connection_get_loop (DBusConnection *connection)
++DBusLoop*
++bus_connection_get_loop (DBusConnection *connection)
+ {
+   BusConnectionData *d;
+ 
+@@ -331,7 +338,7 @@ add_connection_watch (DBusWatch      *watch,
+ {
+   DBusConnection *connection = data;
+ 
+-  return _dbus_loop_add_watch (connection_get_loop (connection), watch);
++  return _dbus_loop_add_watch (bus_connection_get_loop (connection), watch);
+ }
+ 
+ static void
+@@ -340,7 +347,7 @@ remove_connection_watch (DBusWatch      *watch,
+ {
+   DBusConnection *connection = data;
+   
+-  _dbus_loop_remove_watch (connection_get_loop (connection), watch);
++  _dbus_loop_remove_watch (bus_connection_get_loop (connection), watch);
+ }
+ 
+ static void
+@@ -349,7 +356,7 @@ toggle_connection_watch (DBusWatch      *watch,
+ {
+   DBusConnection *connection = data;
+ 
+-  _dbus_loop_toggle_watch (connection_get_loop (connection), watch);
++  _dbus_loop_toggle_watch (bus_connection_get_loop (connection), watch);
+ }
+ 
+ static dbus_bool_t
+@@ -358,7 +365,7 @@ add_connection_timeout (DBusTimeout    *timeout,
+ {
+   DBusConnection *connection = data;
+   
+-  return _dbus_loop_add_timeout (connection_get_loop (connection), timeout);
++  return _dbus_loop_add_timeout (bus_connection_get_loop (connection), timeout);
+ }
+ 
+ static void
+@@ -367,7 +374,7 @@ remove_connection_timeout (DBusTimeout    *timeout,
+ {
+   DBusConnection *connection = data;
+   
+-  _dbus_loop_remove_timeout (connection_get_loop (connection), timeout);
++  _dbus_loop_remove_timeout (bus_connection_get_loop (connection), timeout);
+ }
+ 
+ static void
+@@ -425,6 +432,10 @@ free_connection_data (void *data)
+   
+   dbus_free (d->name);
+   
++#ifdef DBUS_ENABLE_CYNARA
++  free (d->cynara_session_id);
++#endif
++
+   dbus_free (d);
+ }
+ 
+@@ -976,6 +987,22 @@ bus_connection_get_policy (DBusConnection *connection)
+   return d->policy;
+ }
+ 
++#ifdef DBUS_ENABLE_CYNARA
++const char *bus_connection_get_cynara_session_id (DBusConnection *connection)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA (connection);
++  _dbus_assert (d != NULL);
++
++  if (d->cynara_session_id == NULL)
++    {
++      unsigned long pid;
++      if (dbus_connection_get_unix_process_id(connection, &pid))
++        d->cynara_session_id = cynara_session_from_pid(pid);
++    }
++  return d->cynara_session_id;
++}
++#endif
++
+ static dbus_bool_t
+ foreach_active (BusConnections               *connections,
+                 BusConnectionForeachFunction  function,
+@@ -2124,10 +2151,21 @@ bus_transaction_send_from_driver (BusTransaction *transaction,
+   /* If security policy doesn't allow the message, we silently
+    * eat it; the driver doesn't care about getting a reply.
+    */
+-  if (!bus_context_check_security_policy (bus_transaction_get_context (transaction),
+-                                          transaction,
+-                                          NULL, connection, connection, message, NULL))
+-    return TRUE;
++  switch (bus_context_check_security_policy (bus_transaction_get_context (transaction),
++                                             transaction,
++                                             NULL, connection, connection, message, NULL,
++                                             NULL))
++    {
++    case BUS_RESULT_TRUE:
++      break;
++    case BUS_RESULT_FALSE:
++      return TRUE;
++      break;
++    case BUS_RESULT_LATER:
++      _dbus_verbose ("Cannot delay sending message from bus driver, dropping it\n");
++      return TRUE;
++      break;
++    }
+ 
+   return bus_transaction_send (transaction, connection, message);
+ }
+diff --git a/bus/connection.h b/bus/connection.h
+index 6fbcd38..7433746 100644
+--- a/bus/connection.h
++++ b/bus/connection.h
+@@ -31,6 +31,7 @@
+ typedef dbus_bool_t (* BusConnectionForeachFunction) (DBusConnection *connection, 
+                                                       void           *data);
+ 
++DBusLoop*       bus_connection_get_loop           (DBusConnection *connection);
+ 
+ BusConnections* bus_connections_new               (BusContext                   *context);
+ BusConnections* bus_connections_ref               (BusConnections               *connections);
+@@ -116,6 +117,10 @@ dbus_bool_t      bus_connection_get_unix_groups  (DBusConnection       *connecti
+                                                   DBusError            *error);
+ BusClientPolicy* bus_connection_get_policy  (DBusConnection       *connection);
+ 
++#ifdef DBUS_ENABLE_CYNARA
++const char *bus_connection_get_cynara_session_id (DBusConnection *connection);
++#endif
++
+ /* transaction API so we can send or not send a block of messages as a whole */
+ 
+ typedef void (* BusTransactionCancelFunction) (void *data);
+diff --git a/bus/cynara.c b/bus/cynara.c
+new file mode 100644
+index 0000000..d659574
+--- /dev/null
++++ b/bus/cynara.c
+@@ -0,0 +1,332 @@
++/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
++/* cynara.c  Cynara runtime privilege checking
++ *
++ * Copyright (c) 2014 Samsung Electronics, Ltd.
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#include <config.h>
++#include "cynara.h"
++#include "check.h"
++#include "utils.h"
++
++#include <stdio.h>
++
++#include <dbus/dbus.h>
++#include <dbus/dbus-watch.h>
++#include <bus/connection.h>
++#ifdef DBUS_ENABLE_CYNARA
++#include <cynara-client-async.h>
++#endif
++
++
++#ifdef DBUS_ENABLE_CYNARA
++typedef struct BusCynara
++{
++  int refcount;
++
++  BusContext   *context;
++  BusCheck     *check;
++  cynara_async *cynara;
++  DBusWatch    *cynara_watch;
++} BusCynara;
++
++static dbus_bool_t bus_cynara_watch_callback(DBusWatch *watch,
++                                             unsigned int flags,
++                                             void *data);
++
++static void status_callback(int old_fd,
++                            int new_fd,
++                            cynara_async_status status,
++                            void *user_status_data);
++static void bus_cynara_check_response_callback (cynara_check_id check_id,
++                                                cynara_async_call_cause cause,
++                                                int response,
++                                                void *user_response_data);
++#endif
++
++
++BusCynara *
++bus_cynara_new(BusCheck *check, DBusError *error)
++{
++#ifdef DBUS_ENABLE_CYNARA
++  BusContext *context;
++  BusCynara *cynara;
++  int ret;
++
++  cynara = dbus_new(BusCynara, 1);
++  if (cynara == NULL)
++    {
++      BUS_SET_OOM(error);
++      return NULL;
++    }
++
++  context = bus_check_get_context(check);
++
++  cynara->refcount = 1;
++  cynara->check = check;
++  cynara->context = context;
++  cynara->cynara_watch = NULL;
++
++  ret = cynara_async_initialize(&cynara->cynara, NULL, &status_callback, cynara);
++  if (ret != CYNARA_API_SUCCESS)
++    {
++      dbus_set_error (error, DBUS_ERROR_FAILED, "Failed to initialize Cynara client");
++      dbus_free(cynara);
++      return NULL;
++    }
++
++  return cynara;
++#else
++  return NULL;
++#endif
++}
++
++BusCynara *
++bus_cynara_ref (BusCynara *cynara)
++{
++#ifdef DBUS_ENABLE_CYNARA
++  _dbus_assert (cynara->refcount > 0);
++  cynara->refcount += 1;
++
++  return cynara;
++#else
++  return NULL;
++#endif
++}
++
++void
++bus_cynara_unref (BusCynara *cynara)
++{
++#ifdef DBUS_ENABLE_CYNARA
++  _dbus_assert (cynara->refcount > 0);
++
++  cynara->refcount -= 1;
++
++  if (cynara->refcount == 0)
++    {
++      if (cynara->cynara != NULL)
++        cynara_async_finish(cynara->cynara);
++      dbus_free(cynara);
++    }
++#endif
++}
++
++BusResult
++bus_cynara_check_privilege (BusCynara *cynara,
++                            DBusMessage *message,
++                            DBusConnection *sender,
++                            DBusConnection *addressed_recipient,
++                            DBusConnection *proposed_recipient,
++                            const char *privilege,
++                            BusDeferredMessageStatus check_type,
++                            BusDeferredMessage **deferred_message_param)
++{
++#ifdef DBUS_ENABLE_CYNARA
++  int result;
++  unsigned long uid;
++  const char *label;
++  const char *session_id;
++  char user[32];
++  cynara_check_id check_id;
++  DBusConnection *connection = check_type == BUS_DEFERRED_MESSAGE_CHECK_RECEIVE ? proposed_recipient : sender;
++  BusDeferredMessage *deferred_message;
++
++  _dbus_assert(connection != NULL);
++
++  if (dbus_connection_get_unix_user(connection, &uid) == FALSE)
++      return BUS_RESULT_FALSE;
++
++#ifdef DBUS_ENABLE_SMACK
++  if (dbus_connection_get_smack_label (connection, &label) == FALSE)
++      return BUS_RESULT_FALSE;
++#else
++#error Cannot get connection label with smack disabled
++#endif
++
++  session_id = bus_connection_get_cynara_session_id (connection);
++  if (session_id == NULL)
++    return BUS_RESULT_FALSE;
++
++  snprintf(user, sizeof(user), "%lu", uid);
++
++
++  result = cynara_async_check_cache(cynara->cynara, label, session_id, user, privilege);
++  switch (result)
++  {
++  case CYNARA_API_ACCESS_ALLOWED:
++    _dbus_verbose("Cynara: got ALLOWED answer from cache (client=%s session_id=%s user=%s privilege=%s)\n",
++               label, session_id, user, privilege);
++    return BUS_RESULT_TRUE;
++
++  case CYNARA_API_ACCESS_DENIED:
++    _dbus_verbose("Cynara: got DENIED answer from cache (client=%s session_id=%s user=%s privilege=%s)\n",
++               label, session_id, user, privilege);
++    return BUS_RESULT_FALSE;
++
++  case CYNARA_API_CACHE_MISS:
++     deferred_message = bus_deferred_message_new(message, sender, addressed_recipient,
++         proposed_recipient, BUS_RESULT_LATER);
++     if (deferred_message == NULL)
++       {
++         _dbus_verbose("Failed to allocate memory for deferred message\n");
++         return BUS_RESULT_FALSE;
++       }
++
++    /* callback is supposed to unref deferred_message*/
++    result = cynara_async_create_request(cynara->cynara, label, session_id, user, privilege, &check_id,
++        &bus_cynara_check_response_callback, deferred_message);
++    if (result == CYNARA_API_SUCCESS)
++      {
++        _dbus_verbose("Created Cynara request: client=%s session_id=%s user=%s privilege=%s check_id=%u "
++            "deferred_message=%p\n", label, session_id, user, privilege, (unsigned int)check_id, deferred_message);
++        if (deferred_message_param != NULL)
++          *deferred_message_param = deferred_message;
++        return BUS_RESULT_LATER;
++      }
++    else
++      {
++        _dbus_verbose("Error on cynara request create: %i\n", result);
++        bus_deferred_message_unref(deferred_message);
++        return BUS_RESULT_FALSE;
++      }
++    break;
++  default:
++    _dbus_verbose("Error when accessing Cynara cache: %i\n", result);
++    return BUS_RESULT_FALSE;
++  }
++
++#else
++  return BUS_RESULT_FALSE;
++#endif
++}
++
++
++
++#ifdef DBUS_ENABLE_CYNARA
++static void
++status_callback(int old_fd, int new_fd, cynara_async_status status,
++                void *user_status_data)
++{
++  BusCynara *cynara = (BusCynara *)user_status_data;
++  DBusLoop *loop = bus_context_get_loop(cynara->context);
++
++  if (cynara->cynara_watch != NULL)
++    {
++      _dbus_loop_remove_watch(loop, cynara->cynara_watch);
++      _dbus_watch_invalidate(cynara->cynara_watch);
++      _dbus_watch_unref(cynara->cynara_watch);
++      cynara->cynara_watch = NULL;
++    }
++
++  if (new_fd != -1)
++    {
++      unsigned int flags;
++      DBusWatch *watch;
++
++      switch (status)
++      {
++      case CYNARA_STATUS_FOR_READ:
++        flags = DBUS_WATCH_READABLE;
++        break;
++      case CYNARA_STATUS_FOR_RW:
++        flags = DBUS_WATCH_READABLE | DBUS_WATCH_WRITABLE;
++        break;
++      default:
++        /* Cynara passed unknown status - warn and add RW watch */
++        _dbus_verbose("Cynara passed unknown status value: 0x%08X\n", (unsigned int)status);
++        flags = DBUS_WATCH_READABLE | DBUS_WATCH_WRITABLE;
++        break;
++      }
++
++      watch = _dbus_watch_new(new_fd, flags, TRUE, &bus_cynara_watch_callback, cynara, NULL);
++      if (watch != NULL)
++        {
++          if (_dbus_loop_add_watch(loop, watch) == TRUE)
++            {
++              cynara->cynara_watch = watch;
++              return;
++            }
++
++          _dbus_watch_invalidate(watch);
++          _dbus_watch_unref(watch);
++        }
++
++      /* It seems like not much can be done at this point. Cynara events won't be processed
++       * until next Cynara function call triggering status callback */
++      _dbus_verbose("Failed to add dbus watch\n");
++    }
++}
++
++static dbus_bool_t
++bus_cynara_watch_callback(DBusWatch    *watch,
++                          unsigned int  flags,
++                          void         *data)
++{
++  BusCynara *cynara = (BusCynara *)data;
++  int result = cynara_async_process(cynara->cynara);
++  if (result != CYNARA_API_SUCCESS)
++      _dbus_verbose("cynara_async_process returned %d\n", result);
++
++  return result != CYNARA_API_OUT_OF_MEMORY ? TRUE : FALSE;
++}
++
++static inline const char *
++call_cause_to_string(cynara_async_call_cause cause)
++{
++  switch (cause)
++  {
++  case CYNARA_CALL_CAUSE_ANSWER:
++    return "ANSWER";
++  case CYNARA_CALL_CAUSE_CANCEL:
++    return "CANCEL";
++  case CYNARA_CALL_CAUSE_FINISH:
++    return "FINSIH";
++  case CYNARA_CALL_CAUSE_SERVICE_NOT_AVAILABLE:
++    return "SERVICE NOT AVAILABLE";
++  default:
++    return "INVALID";
++  }
++}
++
++static void
++bus_cynara_check_response_callback (cynara_check_id check_id,
++                                    cynara_async_call_cause cause,
++                                    int response,
++                                    void *user_response_data)
++{
++  BusDeferredMessage *deferred_message = user_response_data;
++  BusResult result;
++
++  _dbus_verbose("Cynara callback: check_id=%u, cause=%s response=%i response_data=%p\n",
++      (unsigned int)check_id, call_cause_to_string(cause), response, user_response_data);
++
++  if (deferred_message == NULL)
++    return;
++
++  if (cause == CYNARA_CALL_CAUSE_ANSWER && response == CYNARA_API_ACCESS_ALLOWED)
++    result = BUS_RESULT_TRUE;
++  else
++    result = BUS_RESULT_FALSE;
++
++  bus_deferred_message_response_received(deferred_message, result);
++  bus_deferred_message_unref(deferred_message);
++}
++
++#endif /* DBUS_ENABLE_CYNARA */
+diff --git a/bus/cynara.h b/bus/cynara.h
+new file mode 100644
+index 0000000..c4728bb
+--- /dev/null
++++ b/bus/cynara.h
+@@ -0,0 +1,37 @@
++/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
++/* cynara.h  Cynara runtime privilege checking
++ *
++ * Copyright (c) 2014 Samsung Electronics, Ltd.
++ *
++ * Licensed under the Academic Free License version 2.1
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#include "bus.h"
++#include "check.h"
++
++BusCynara *bus_cynara_new             (BusCheck *check, DBusError *error);
++BusCynara *bus_cynara_ref             (BusCynara *cynara);
++void       bus_cynara_unref           (BusCynara *cynara);
++BusResult  bus_cynara_check_privilege (BusCynara *cynara,
++                                       DBusMessage *message,
++                                       DBusConnection *sender,
++                                       DBusConnection *addressed_recipient,
++                                       DBusConnection *proposed_recipient,
++                                       const char *privilege,
++                                       BusDeferredMessageStatus check_type,
++                                       BusDeferredMessage **deferred_message);
+diff --git a/bus/dispatch.c b/bus/dispatch.c
+index 7a61953..556715d 100644
+--- a/bus/dispatch.c
++++ b/bus/dispatch.c
+@@ -25,6 +25,7 @@
+ 
+ #include <config.h>
+ #include "dispatch.h"
++#include "check.h"
+ #include "connection.h"
+ #include "driver.h"
+ #include "services.h"
+@@ -56,13 +57,14 @@ send_one_message (DBusConnection *connection,
+                   BusTransaction *transaction,
+                   DBusError      *error)
+ {
+-  if (!bus_context_check_security_policy (context, transaction,
+-                                          sender,
+-                                          addressed_recipient,
+-                                          connection,
+-                                          message,
+-                                          NULL))
+-    return TRUE; /* silently don't send it */
++  BusDeferredMessage *deferred_message;
++  BusResult result;
++
++  result = bus_context_check_security_policy (context, transaction, sender, addressed_recipient,
++      connection, message, NULL, &deferred_message);
++
++  if (result != BUS_RESULT_TRUE)
++      return TRUE; /* silently don't send it */
+ 
+   if (dbus_message_contains_unix_fds(message) &&
+       !dbus_connection_can_send_type(connection, DBUS_TYPE_UNIX_FD))
+@@ -92,6 +94,7 @@ bus_dispatch_matches (BusTransaction *transaction,
+   BusMatchmaker *matchmaker;
+   DBusList *link;
+   BusContext *context;
++  BusDeferredMessage *deferred_message;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+ 
+@@ -107,11 +110,22 @@ bus_dispatch_matches (BusTransaction *transaction,
+   /* First, send the message to the addressed_recipient, if there is one. */
+   if (addressed_recipient != NULL)
+     {
+-      if (!bus_context_check_security_policy (context, transaction,
+-                                              sender, addressed_recipient,
+-                                              addressed_recipient,
+-                                              message, error))
+-        return FALSE;
++      switch (bus_context_check_security_policy (context, transaction,
++                                                 sender, addressed_recipient,
++                                                 addressed_recipient,
++                                                 message, error,
++                                                 &deferred_message))
++        {
++          case BUS_RESULT_TRUE:
++            break;
++          case BUS_RESULT_FALSE:
++            return BUS_RESULT_FALSE;
++          case BUS_RESULT_LATER:
++            dbus_set_error (error,
++                            DBUS_ERROR_ACCESS_DENIED,
++                            "Rejecting message because time is needed to check security policy");
++            return BUS_RESULT_FALSE;
++        }
+ 
+       if (dbus_message_contains_unix_fds (message) &&
+           !dbus_connection_can_send_type (addressed_recipient,
+@@ -273,11 +287,22 @@ bus_dispatch (DBusConnection *connection,
+   if (service_name &&
+       strcmp (service_name, DBUS_SERVICE_DBUS) == 0) /* to bus driver */
+     {
+-      if (!bus_context_check_security_policy (context, transaction,
+-                                              connection, NULL, NULL, message, &error))
++      BusDeferredMessage *deferred_message;
++      switch (bus_context_check_security_policy (context, transaction,
++                                                 connection, NULL, NULL, message, &error,
++                                                 &deferred_message))
+         {
++        case BUS_RESULT_TRUE:
++          break;
++        case BUS_RESULT_FALSE:
+           _dbus_verbose ("Security policy rejected message\n");
+           goto out;
++        case BUS_RESULT_LATER:
++          dbus_set_error (&error,
++                          DBUS_ERROR_ACCESS_DENIED,
++                          "Rejecting message because time is needed to check security policy");
++          _dbus_verbose ("Security policy needs time to check policy. Dropping message\n");
++          goto out;
+         }
+ 
+       _dbus_verbose ("Giving message to %s\n", DBUS_SERVICE_DBUS);
+diff --git a/bus/policy.c b/bus/policy.c
+index 5af5b6b..825d754 100644
+--- a/bus/policy.c
++++ b/bus/policy.c
+@@ -22,6 +22,7 @@
+  */
+ 
+ #include <config.h>
++#include "check.h"
+ #include "policy.h"
+ #include "services.h"
+ #include "test.h"
+@@ -992,17 +993,22 @@ bus_client_policy_append_rule (BusClientPolicy *policy,
+   return TRUE;
+ }
+ 
+-dbus_bool_t
+-bus_client_policy_check_can_send (BusClientPolicy *policy,
+-                                  BusRegistry     *registry,
+-                                  dbus_bool_t      requested_reply,
+-                                  DBusConnection  *receiver,
+-                                  DBusMessage     *message,
+-                                  dbus_int32_t    *toggles,
+-                                  dbus_bool_t     *log)
++BusResult
++bus_client_policy_check_can_send (DBusConnection      *sender,
++                                  BusClientPolicy     *policy,
++                                  BusRegistry         *registry,
++                                  dbus_bool_t          requested_reply,
++                                  DBusConnection      *addressed_recipient,
++                                  DBusConnection      *receiver,
++                                  DBusMessage         *message,
++                                  dbus_int32_t        *toggles,
++                                  dbus_bool_t         *log,
++                                  const char         **privilege_param,
++                                  BusDeferredMessage **deferred_message)
+ {
+   DBusList *link;
+-  dbus_bool_t allowed;
++  BusResult result;
++  const char *privilege;
+ 
+   /* policy->rules is in the order the rules appeared
+    * in the config file, i.e. last rule that applies wins
+@@ -1011,7 +1017,7 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+   _dbus_verbose ("  (policy) checking send rules\n");
+   *toggles = 0;
+   
+-  allowed = FALSE;
++  result = BUS_RESULT_FALSE;
+   link = _dbus_list_get_first_link (&policy->rules);
+   while (link != NULL)
+     {
+@@ -1162,33 +1168,63 @@ bus_client_policy_check_can_send (BusClientPolicy *policy,
+         }
+ 
+       /* Use this rule */
+-      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
++      switch (rule->access)
++        {
++        case BUS_POLICY_RULE_ACCESS_ALLOW:
++          result = BUS_RESULT_TRUE;
++          break;
++        case BUS_POLICY_RULE_ACCESS_DENY:
++          result = BUS_RESULT_FALSE;
++          break;
++        case BUS_POLICY_RULE_ACCESS_CHECK:
++          result = BUS_RESULT_LATER;
++          privilege = rule->privilege;
++          break;
++        }
++
+       *log = rule->d.send.log;
+       (*toggles)++;
+ 
+-      _dbus_verbose ("  (policy) used rule, allow now = %d\n",
+-                     allowed);
++      _dbus_verbose ("  (policy) used rule, result now = %d\n",
++                     result);
+     }
+ 
+-  return allowed;
++  if (result == BUS_RESULT_LATER)
++    {
++      BusContext *context = bus_connection_get_context(sender);
++      BusCheck *check = bus_context_get_check(context);
++
++      result = bus_check_privilege(check, message, sender, addressed_recipient, receiver,
++          privilege, BUS_DEFERRED_MESSAGE_CHECK_SEND, deferred_message);
++    }
++  else
++    privilege = NULL;
++
++  if (privilege_param != NULL)
++    *privilege_param = privilege;
++
++  return result;
+ }
+ 
+ /* See docs on what the args mean on bus_context_check_security_policy()
+  * comment
+  */
+-dbus_bool_t
+-bus_client_policy_check_can_receive (BusClientPolicy *policy,
+-                                     BusRegistry     *registry,
+-                                     dbus_bool_t      requested_reply,
+-                                     DBusConnection  *sender,
+-                                     DBusConnection  *addressed_recipient,
+-                                     DBusConnection  *proposed_recipient,
+-                                     DBusMessage     *message,
+-                                     dbus_int32_t    *toggles)
++BusResult
++bus_client_policy_check_can_receive (BusClientPolicy     *policy,
++                                     BusRegistry         *registry,
++                                     dbus_bool_t          requested_reply,
++                                     DBusConnection      *sender,
++                                     DBusConnection      *addressed_recipient,
++                                     DBusConnection      *proposed_recipient,
++                                     DBusMessage         *message,
++                                     dbus_int32_t        *toggles,
++                                     const char         **privilege_param,
++                                     BusDeferredMessage **deferred_message)
+ {
+   DBusList *link;
+-  dbus_bool_t allowed;
+   dbus_bool_t eavesdropping;
++  BusResult result;
++  const char *privilege;
+ 
+   eavesdropping =
+     addressed_recipient != proposed_recipient &&
+@@ -1201,7 +1237,7 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+   _dbus_verbose ("  (policy) checking receive rules, eavesdropping = %d\n", eavesdropping);
+   *toggles = 0;
+   
+-  allowed = FALSE;
++  result = BUS_RESULT_FALSE;
+   link = _dbus_list_get_first_link (&policy->rules);
+   while (link != NULL)
+     {
+@@ -1366,14 +1402,42 @@ bus_client_policy_check_can_receive (BusClientPolicy *policy,
+         }
+       
+       /* Use this rule */
+-      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
++      switch (rule->access)
++      {
++        case BUS_POLICY_RULE_ACCESS_ALLOW:
++          result = BUS_RESULT_TRUE;
++          break;
++        case BUS_POLICY_RULE_ACCESS_DENY:
++          result = BUS_RESULT_FALSE;
++          break;
++        case BUS_POLICY_RULE_ACCESS_CHECK:
++          result = BUS_RESULT_LATER;
++          privilege = rule->privilege;
++          break;
++      }
++
+       (*toggles)++;
+ 
+-      _dbus_verbose ("  (policy) used rule, allow now = %d\n",
+-                     allowed);
++      _dbus_verbose ("  (policy) used rule, result now = %d\n",
++                     result);
+     }
+ 
+-  return allowed;
++
++  if (result == BUS_RESULT_LATER)
++    {
++      BusContext *context = bus_connection_get_context(proposed_recipient);
++      BusCheck *check = bus_context_get_check(context);
++
++      result = bus_check_privilege(check, message, sender, addressed_recipient, proposed_recipient,
++                 privilege, BUS_DEFERRED_MESSAGE_CHECK_RECEIVE, deferred_message);
++    }
++  else
++      privilege = NULL;
++
++  if (privilege_param != NULL)
++     *privilege_param = privilege;
++
++  return result;
+ }
+ 
+ 
+diff --git a/bus/policy.h b/bus/policy.h
+index fd66bcb..08979d2 100644
+--- a/bus/policy.h
++++ b/bus/policy.h
+@@ -152,21 +152,27 @@ dbus_bool_t      bus_policy_merge                 (BusPolicy        *policy,
+ BusClientPolicy* bus_client_policy_new               (void);
+ BusClientPolicy* bus_client_policy_ref               (BusClientPolicy  *policy);
+ void             bus_client_policy_unref             (BusClientPolicy  *policy);
+-dbus_bool_t      bus_client_policy_check_can_send    (BusClientPolicy  *policy,
+-                                                      BusRegistry      *registry,
+-                                                      dbus_bool_t       requested_reply,
+-                                                      DBusConnection   *receiver,
+-                                                      DBusMessage      *message,
+-                                                      dbus_int32_t     *toggles,
+-                                                      dbus_bool_t      *log);
+-dbus_bool_t      bus_client_policy_check_can_receive (BusClientPolicy  *policy,
+-                                                      BusRegistry      *registry,
+-                                                      dbus_bool_t       requested_reply,
+-                                                      DBusConnection   *sender,
+-                                                      DBusConnection   *addressed_recipient,
+-                                                      DBusConnection   *proposed_recipient,
+-                                                      DBusMessage      *message,
+-                                                      dbus_int32_t     *toggles);
++BusResult        bus_client_policy_check_can_send    (DBusConnection      *sender,
++                                                      BusClientPolicy     *policy,
++                                                      BusRegistry         *registry,
++                                                      dbus_bool_t          requested_reply,
++                                                      DBusConnection      *addressed_recipient,
++                                                      DBusConnection      *receiver,
++                                                      DBusMessage         *message,
++                                                      dbus_int32_t        *toggles,
++                                                      dbus_bool_t         *log,
++                                                      const char         **privilege_param,
++                                                      BusDeferredMessage **deferred_message);
++BusResult        bus_client_policy_check_can_receive (BusClientPolicy     *policy,
++                                                      BusRegistry         *registry,
++                                                      dbus_bool_t          requested_reply,
++                                                      DBusConnection      *sender,
++                                                      DBusConnection      *addressed_recipient,
++                                                      DBusConnection      *proposed_recipient,
++                                                      DBusMessage         *message,
++                                                      dbus_int32_t        *toggles,
++                                                      const char         **privilege_param,
++                                                      BusDeferredMessage **deferred_message);
+ dbus_bool_t      bus_client_policy_check_can_own     (BusClientPolicy  *policy,
+                                                       const DBusString *service_name);
+ dbus_bool_t      bus_client_policy_append_rule       (BusClientPolicy  *policy,
+diff --git a/configure.ac b/configure.ac
+index c0ec075..4ec4d80 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1755,6 +1755,18 @@ fi
+ AC_SUBST([LIBSMACK_CFLAGS])
+ AC_SUBST([LIBSMACK_LIBS])
+ 
++#enable cynara integration
++AC_ARG_ENABLE([cynara], [AS_HELP_STRING([--enable-cynara], [enable Cynara integration])], [], [enable_cynara=no])
++if test "x$enable_cynara" = xyes; then
++  PKG_CHECK_MODULES([CYNARA], [cynara-client-async >= 0.4.2 cynara-session >= 0.4.2],
++     [AC_DEFINE([DBUS_ENABLE_CYNARA], [1], [Define to enable Cynara privilege checks in dbus-daemon])],
++     [AC_MSG_ERROR([libcynara-client-async and cynara-session are required to enable Cynara integration])])
++fi
++
++AC_SUBST([CYNARA_CFLAGS])
++AC_SUBST([CYNARA_LIBS])
++
++
+ AC_CONFIG_FILES([
+ Doxyfile
+ dbus/versioninfo.rc
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0007-Disable-message-dispatching-when-send-rule-result-is.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0007-Disable-message-dispatching-when-send-rule-result-is.patch
@@ -1,0 +1,810 @@
+From 646546dd71507d2135a16e1329663fa73137c7fc Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Fri, 28 Nov 2014 12:07:39 +0100
+Subject: [PATCH 07/13] Disable message dispatching when send rule result is
+ not known
+
+When unicast message to addressed recipient is sent and policy result
+is not available message dispatch from the sender is disabled.
+This also means that any further messages from the given connection are
+put into the incoming queue. If response is received message dispatching
+is resumed. This time answer is expected to be in cache so the message is
+processed synchronously.
+Receive rule result unavailability is not yet handled - such messages are
+rejected. Also, if message is sent to non-addressed recipient message
+is silently dropped.
+
+Change-Id: Ia45905baf667ca42f386c1def108eca190d615bb
+---
+ bus/activation.c                |  81 +++++++++++++++--
+ bus/check.c                     |  34 ++++++++
+ bus/check.h                     |  10 +++
+ bus/dispatch.c                  | 187 ++++++++++++++++++++++++++++++++++++----
+ bus/dispatch.h                  |   2 +-
+ bus/driver.c                    |  15 +++-
+ dbus/dbus-connection-internal.h |  10 +++
+ dbus/dbus-connection.c          | 125 +++++++++++++++++++++++++--
+ dbus/dbus-list.c                |  29 +++++++
+ dbus/dbus-list.h                |   2 +
+ dbus/dbus-shared.h              |   3 +-
+ 11 files changed, 466 insertions(+), 32 deletions(-)
+
+diff --git a/bus/activation.c b/bus/activation.c
+index ecd19bb..0722384 100644
+--- a/bus/activation.c
++++ b/bus/activation.c
+@@ -31,6 +31,7 @@
+ #include "services.h"
+ #include "test.h"
+ #include "utils.h"
++#include <dbus/dbus-connection-internal.h>
+ #include <dbus/dbus-internals.h>
+ #include <dbus/dbus-hash.h>
+ #include <dbus/dbus-list.h>
+@@ -91,6 +92,8 @@ struct BusPendingActivationEntry
+   DBusConnection *connection;
+ 
+   dbus_bool_t auto_activation;
++
++  dbus_bool_t is_put_back;
+ };
+ 
+ typedef struct
+@@ -1180,7 +1183,8 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+       BusPendingActivationEntry *entry = link->data;
+       DBusList *next = _dbus_list_get_next_link (&pending_activation->entries, link);
+ 
+-      if (entry->auto_activation && (entry->connection == NULL || dbus_connection_get_is_connected (entry->connection)))
++      if (entry->auto_activation && !entry->is_put_back &&
++          (entry->connection == NULL || dbus_connection_get_is_connected (entry->connection)))
+         {
+           DBusConnection *addressed_recipient;
+           DBusError error;
+@@ -1190,11 +1194,14 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+           addressed_recipient = bus_service_get_primary_owners_connection (service);
+ 
+           /* Resume dispatching where we left off in bus_dispatch() */
+-          if (!bus_dispatch_matches (transaction,
+-                                     entry->connection,
+-                                     addressed_recipient,
+-                                     entry->activation_message, &error))
++          switch (bus_dispatch_matches (transaction,
++                                        entry->connection,
++                                        addressed_recipient,
++                                        entry->activation_message, &error))
+             {
++            case BUS_RESULT_TRUE:
++              break;
++            case BUS_RESULT_FALSE:
+               /* If permission is denied, we just want to return the error
+                * to the original method invoker; in particular, we don't
+                * want to make the RequestName call fail with that error
+@@ -1208,6 +1215,41 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+ 
+               link = next;
+               continue;
++            case BUS_RESULT_LATER:
++              {
++                DBusList *putback_message_link = link;
++                DBusMessage *last_inserted_message = NULL;
++
++                /* NULL entry->connection implies sending pending ActivationRequest message to systemd */
++                if (entry->connection == NULL)
++                  {
++                    _dbus_assert_not_reached ("bus_dispatch_matches returned BUS_RESULT_LATER unexpectedly when sender is NULL");
++                    link = next;
++                    continue;
++                  }
++
++                /**
++                 * Getting here means that policy check result is not yet available and dispatching
++                 * messages from entry->connection has been disabled.
++                 * Let's put back all messages for the given connection in the incoming queue and mark
++                 * this entry as put back so they are not handled twice.
++                 */
++                while (putback_message_link != NULL)
++                  {
++                    BusPendingActivationEntry *putback_message = putback_message_link->data;
++                    if (putback_message->connection == entry->connection)
++                      {
++                        if (!_dbus_connection_putback_message (putback_message->connection, last_inserted_message,
++                              putback_message->activation_message, error))
++                          goto error;
++                        last_inserted_message = putback_message->activation_message;
++                        putback_message->is_put_back = TRUE;
++                      }
++
++                    putback_message_link = _dbus_list_get_next_link(&pending_activation->entries, putback_message_link);
++                  }
++                break;
++              }
+             }
+         }
+ 
+@@ -1225,6 +1267,19 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+   return TRUE;
+ 
+  error:
++  /* remove all messages that have been put to connections' incoming queues */
++  link = _dbus_list_get_first_link (&pending_activation->entries);
++  while (link != NULL)
++    {
++      BusPendingActivationEntry *entry = link->data;
++      if (entry->is_put_back)
++        {
++          _dbus_connection_remove_message(entry->connection, entry->activation_message);
++          entry->is_put_back = FALSE;
++        }
++      link = _dbus_list_get_next_link(&pending_activation->entries, link);
++    }
++
+   return FALSE;
+ }
+ 
+@@ -2014,8 +2069,20 @@ bus_activation_activate_service (BusActivation  *activation,
+                                service_name,
+                                entry->systemd_service);
+               /* Wonderful, systemd is connected, let's just send the msg */
+-              retval = bus_dispatch_matches (activation_transaction, NULL, bus_service_get_primary_owners_connection (service),
+-                                             message, error);
++              switch (bus_dispatch_matches (activation_transaction, NULL, bus_service_get_primary_owners_connection (service),
++                                            message, error))
++                {
++                case BUS_RESULT_TRUE:
++                  retval = TRUE;
++                  break;
++                case BUS_RESULT_FALSE:
++                  retval = FALSE;
++                  break;
++                case BUS_RESULT_LATER:
++                  _dbus_verbose("Unexpectedly need time to check message from bus driver to systemd - dropping the message.\n");
++                  retval = FALSE;
++                  break;
++                }
+             }
+           else
+             {
+diff --git a/bus/check.c b/bus/check.c
+index d2f418a..a5dbaff 100644
+--- a/bus/check.c
++++ b/bus/check.c
+@@ -114,6 +114,29 @@ bus_check_get_cynara (BusCheck *check)
+   return check->cynara;
+ }
+ 
++static void
++bus_check_enable_dispatch_callback (BusDeferredMessage *deferred_message,
++                                    BusResult result)
++{
++  _dbus_verbose("bus_check_enable_dispatch_callback called deferred_message=%p\n", deferred_message);
++  _dbus_connection_enable_dispatch(deferred_message->sender);
++}
++
++void
++bus_deferred_message_disable_sender (BusDeferredMessage *deferred_message)
++{
++  _dbus_assert(deferred_message != NULL);
++  _dbus_assert(deferred_message->sender != NULL);
++
++  _dbus_connection_disable_dispatch(deferred_message->sender);
++  deferred_message->response_callback = bus_check_enable_dispatch_callback;
++}
++
++#ifdef DBUS_ENABLE_EMBEDDED_TESTS
++dbus_bool_t (*bus_check_test_override) (DBusConnection *connection,
++                                        const char *privilege);
++#endif
++
+ BusResult
+ bus_check_privilege (BusCheck *check,
+                      DBusMessage *message,
+@@ -135,6 +158,11 @@ bus_check_privilege (BusCheck *check,
+       return BUS_RESULT_FALSE;
+     }
+ 
++#ifdef DBUS_ENABLE_EMBEDDED_TESTS
++  if (bus_check_test_override)
++    return bus_check_test_override (connection, privilege);
++#endif
++
+   /* ask policy checkers */
+ #ifdef DBUS_ENABLE_CYNARA
+   cynara = bus_check_get_cynara(check);
+@@ -204,6 +232,12 @@ bus_deferred_message_unref (BusDeferredMessage *deferred_message)
+      }
+ }
+ 
++BusDeferredMessageStatus
++bus_deferred_message_get_status (BusDeferredMessage *deferred_message)
++{
++  return deferred_message->status;
++}
++
+ void
+ bus_deferred_message_response_received (BusDeferredMessage *deferred_message,
+                                         BusResult result)
+diff --git a/bus/check.h b/bus/check.h
+index c3fcaf9..f381789 100644
+--- a/bus/check.h
++++ b/bus/check.h
+@@ -55,6 +55,7 @@ BusResult   bus_check_privilege   (BusCheck *check,
+                                    BusDeferredMessageStatus check_type,
+                                    BusDeferredMessage **deferred_message);
+ 
++
+ BusDeferredMessage *bus_deferred_message_new                (DBusMessage *message,
+                                                              DBusConnection *sender,
+                                                              DBusConnection *addressed_recipient,
+@@ -65,4 +66,13 @@ BusDeferredMessage *bus_deferred_message_ref                (BusDeferredMessage
+ void                bus_deferred_message_unref              (BusDeferredMessage *deferred_message);
+ void                bus_deferred_message_response_received  (BusDeferredMessage *deferred_message,
+                                                              BusResult result);
++void                bus_deferred_message_disable_sender     (BusDeferredMessage *deferred_message);
++
++BusDeferredMessageStatus  bus_deferred_message_get_status   (BusDeferredMessage *deferred_message);
++
++#ifdef DBUS_ENABLE_EMBEDDED_TESTS
++extern dbus_bool_t (*bus_check_test_override) (DBusConnection *connection,
++                                               const char *privilege);
++#endif
++
+ #endif /* BUS_CHECK_H */
+diff --git a/bus/dispatch.c b/bus/dispatch.c
+index 556715d..bb81cc0 100644
+--- a/bus/dispatch.c
++++ b/bus/dispatch.c
+@@ -81,7 +81,7 @@ send_one_message (DBusConnection *connection,
+   return TRUE;
+ }
+ 
+-dbus_bool_t
++BusResult
+ bus_dispatch_matches (BusTransaction *transaction,
+                       DBusConnection *sender,
+                       DBusConnection *addressed_recipient,
+@@ -121,10 +121,28 @@ bus_dispatch_matches (BusTransaction *transaction,
+           case BUS_RESULT_FALSE:
+             return BUS_RESULT_FALSE;
+           case BUS_RESULT_LATER:
+-            dbus_set_error (error,
+-                            DBUS_ERROR_ACCESS_DENIED,
+-                            "Rejecting message because time is needed to check security policy");
+-            return BUS_RESULT_FALSE;
++            {
++              BusDeferredMessageStatus status;
++              status = bus_deferred_message_get_status(deferred_message);
++
++              if (status & BUS_DEFERRED_MESSAGE_CHECK_SEND)
++                {
++                  /* send rule result not available - disable dispatching messages from the sender */
++                  bus_deferred_message_disable_sender(deferred_message);
++                  return BUS_RESULT_LATER;
++                }
++              else if (status & BUS_DEFERRED_MESSAGE_CHECK_RECEIVE)
++                {
++                   dbus_set_error (error, DBUS_ERROR_ACCESS_DENIED,
++                              "Rejecting message because time is needed to check security policy");
++                   return BUS_RESULT_FALSE;
++                }
++              else
++                {
++                  _dbus_verbose("deferred message has no status field set to send or receive unexpectedly\n");
++                  return BUS_RESULT_FALSE;
++                }
++            }
+         }
+ 
+       if (dbus_message_contains_unix_fds (message) &&
+@@ -135,14 +153,14 @@ bus_dispatch_matches (BusTransaction *transaction,
+                           DBUS_ERROR_NOT_SUPPORTED,
+                           "Tried to send message with Unix file descriptors"
+                           "to a client that doesn't support that.");
+-          return FALSE;
+-      }
++          return BUS_RESULT_FALSE;
++        }
+ 
+       /* Dispatch the message */
+       if (!bus_transaction_send (transaction, addressed_recipient, message))
+         {
+           BUS_SET_OOM (error);
+-          return FALSE;
++          return BUS_RESULT_FALSE;
+         }
+     }
+ 
+@@ -157,7 +175,7 @@ bus_dispatch_matches (BusTransaction *transaction,
+                                       &recipients))
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   link = _dbus_list_get_first_link (&recipients);
+@@ -179,10 +197,10 @@ bus_dispatch_matches (BusTransaction *transaction,
+   if (dbus_error_is_set (&tmp_error))
+     {
+       dbus_move_error (&tmp_error, error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+   else
+-    return TRUE;
++    return BUS_RESULT_TRUE;
+ }
+ 
+ static DBusHandlerResult
+@@ -298,10 +316,12 @@ bus_dispatch (DBusConnection *connection,
+           _dbus_verbose ("Security policy rejected message\n");
+           goto out;
+         case BUS_RESULT_LATER:
+-          dbus_set_error (&error,
+-                          DBUS_ERROR_ACCESS_DENIED,
+-                          "Rejecting message because time is needed to check security policy");
+-          _dbus_verbose ("Security policy needs time to check policy. Dropping message\n");
++        /* Disable dispatching messages from the sender,
++         * roll back and dispatch the message once the policy result is available */
++          bus_deferred_message_disable_sender(deferred_message);
++          bus_transaction_cancel_and_free (transaction);
++          transaction = NULL;
++          result = DBUS_HANDLER_RESULT_LATER;
+           goto out;
+         }
+ 
+@@ -366,8 +386,18 @@ bus_dispatch (DBusConnection *connection,
+    * addressed_recipient == NULL), and match it against other connections'
+    * match rules.
+    */
+-  if (!bus_dispatch_matches (transaction, connection, addressed_recipient, message, &error))
+-    goto out;
++  switch (bus_dispatch_matches (transaction, connection, addressed_recipient, message, &error))
++    {
++    case BUS_RESULT_TRUE:
++    case BUS_RESULT_FALSE:
++      break;
++    case BUS_RESULT_LATER:
++      /* Roll back and dispatch the message once the policy result is available */
++      bus_transaction_cancel_and_free (transaction);
++      transaction = NULL;
++      result = DBUS_HANDLER_RESULT_LATER;
++      break;
++    }
+ 
+  out:
+   if (dbus_error_is_set (&error))
+@@ -4714,9 +4744,132 @@ bus_dispatch_test_conf_fail (const DBusString *test_data_dir,
+   return TRUE;
+ }
+ 
++typedef struct {
++  DBusTimeout *timeout;
++  DBusConnection *connection;
++  dbus_bool_t timedout;
++  int check_counter;
++} BusTestCheckData;
++
++static BusTestCheckData *cdata;
++
++static dbus_bool_t
++bus_dispatch_test_check_timeout (void *data)
++{
++  _dbus_verbose ("timeout triggered - pretend that privilege check result is available\n");
++
++  /* should only happen once during the test */
++  _dbus_assert (!cdata->timedout);
++  cdata->timedout = TRUE;
++  _dbus_connection_enable_dispatch (cdata->connection);
++
++  /* don't call this again */
++  _dbus_loop_remove_timeout (bus_connection_get_loop (cdata->connection),
++                             cdata->timeout);
++  dbus_connection_unref (cdata->connection);
++  cdata->connection = NULL;
++  return TRUE;
++}
++
++static dbus_bool_t
++bus_dispatch_test_check_override (DBusConnection *connection,
++                                  const char *privilege)
++{
++  _dbus_verbose ("overriding privilege check %s #%d\n", privilege, cdata->check_counter);
++  cdata->check_counter++;
++  if (!cdata->timedout)
++    {
++      dbus_bool_t added;
++
++      /* Should be the first privilege check for the "Echo" method. */
++      _dbus_assert (cdata->check_counter == 1);
++      cdata->timeout = _dbus_timeout_new (1, bus_dispatch_test_check_timeout,
++                                          NULL, NULL);
++      _dbus_assert (cdata->timeout);
++      added = _dbus_loop_add_timeout (bus_connection_get_loop (connection),
++                                      cdata->timeout);
++      _dbus_assert (added);
++      cdata->connection = connection;
++      dbus_connection_ref (connection);
++      _dbus_connection_disable_dispatch (connection);
++      return BUS_RESULT_LATER;
++    }
++  else
++    {
++      /* Should only be checked one more time, and this time succeeds. */
++      _dbus_assert (cdata->check_counter == 2);
++      return BUS_RESULT_TRUE;
++    }
++}
++
++static dbus_bool_t
++bus_dispatch_test_check (const DBusString *test_data_dir)
++{
++  const char *filename = "valid-config-files/debug-check-some.conf";
++  BusContext *context;
++  DBusConnection *foo;
++  DBusError error;
++  dbus_bool_t result = TRUE;
++  BusTestCheckData data;
++
++  /* save the config name for the activation helper */
++  if (!setenv_TEST_LAUNCH_HELPER_CONFIG (test_data_dir, filename))
++    _dbus_assert_not_reached ("no memory setting TEST_LAUNCH_HELPER_CONFIG");
++
++  dbus_error_init (&error);
++
++  context = bus_context_new_test (test_data_dir, filename);
++  if (context == NULL)
++    return FALSE;
++
++  foo = dbus_connection_open_private (TEST_DEBUG_PIPE, &error);
++  if (foo == NULL)
++    _dbus_assert_not_reached ("could not alloc connection");
++
++  if (!bus_setup_debug_client (foo))
++    _dbus_assert_not_reached ("could not set up connection");
++
++  spin_connection_until_authenticated (context, foo);
++
++  if (!check_hello_message (context, foo))
++    _dbus_assert_not_reached ("hello message failed");
++
++  if (!check_double_hello_message (context, foo))
++    _dbus_assert_not_reached ("double hello message failed");
++
++  if (!check_add_match_all (context, foo))
++    _dbus_assert_not_reached ("AddMatch message failed");
++
++  /*
++   * Cause bus_check_send_privilege() to return BUS_RESULT_LATER in the
++   * first call, then BUS_RESULT_TRUE.
++   */
++  cdata = &data;
++  memset (cdata, 0, sizeof(*cdata));
++  bus_check_test_override = bus_dispatch_test_check_override;
++
++  result = check_existent_service_auto_start (context, foo);
++
++  _dbus_assert (cdata->check_counter == 2);
++  _dbus_assert (cdata->timedout);
++  _dbus_assert (cdata->timeout);
++  _dbus_assert (!cdata->connection);
++  _dbus_timeout_unref (cdata->timeout);
++
++  kill_client_connection_unchecked (foo);
++
++  bus_context_unref (context);
++
++  return result;
++}
++
+ dbus_bool_t
+ bus_dispatch_test (const DBusString *test_data_dir)
+ {
++  _dbus_verbose ("<check> tests\n");
++  if (!bus_dispatch_test_check (test_data_dir))
++    return FALSE;
++
+   /* run normal activation tests */
+   _dbus_verbose ("Normal activation tests\n");
+   if (!bus_dispatch_test_conf (test_data_dir,
+diff --git a/bus/dispatch.h b/bus/dispatch.h
+index fb5ba7a..afba6a2 100644
+--- a/bus/dispatch.h
++++ b/bus/dispatch.h
+@@ -29,7 +29,7 @@
+ 
+ dbus_bool_t bus_dispatch_add_connection    (DBusConnection *connection);
+ void        bus_dispatch_remove_connection (DBusConnection *connection);
+-dbus_bool_t bus_dispatch_matches           (BusTransaction *transaction,
++BusResult   bus_dispatch_matches           (BusTransaction *transaction,
+                                             DBusConnection *sender,
+                                             DBusConnection *recipient,
+                                             DBusMessage    *message,
+diff --git a/bus/driver.c b/bus/driver.c
+index 58f184c..a9e670e 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -129,7 +129,20 @@ bus_driver_send_service_owner_changed (const char     *service_name,
+ 
+   _dbus_assert (dbus_message_has_signature (message, "sss"));
+ 
+-  retval = bus_dispatch_matches (transaction, NULL, NULL, message, error);
++  switch (bus_dispatch_matches (transaction, NULL, NULL, message, error))
++    {
++    case BUS_RESULT_TRUE:
++      retval = TRUE;
++      break;
++    case BUS_RESULT_FALSE:
++      retval = FALSE;
++      break;
++    case BUS_RESULT_LATER:
++      /* should never happen */
++      _dbus_assert_not_reached ("bus_dispatch_matches returned BUS_RESULT_LATER unexpectedly");
++      retval = FALSE;
++      break;
++    }
+   dbus_message_unref (message);
+ 
+   return retval;
+diff --git a/dbus/dbus-connection-internal.h b/dbus/dbus-connection-internal.h
+index 2897404..58568df 100644
+--- a/dbus/dbus-connection-internal.h
++++ b/dbus/dbus-connection-internal.h
+@@ -107,6 +107,16 @@ void              _dbus_connection_set_pending_fds_function       (DBusConnectio
+                                                                    DBusPendingFdsChangeFunction callback,
+                                                                    void *data);
+ 
++void              _dbus_connection_enable_dispatch                (DBusConnection *connection);
++void              _dbus_connection_disable_dispatch               (DBusConnection *connection);
++dbus_bool_t       _dbus_connection_putback_message                (DBusConnection *connection,
++                                                                   DBusMessage    *after_message,
++                                                                   DBusMessage    *message,
++                                                                   DBusError      *error);
++
++dbus_bool_t       _dbus_connection_remove_message                 (DBusConnection *connection,
++                                                                   DBusMessage    *message);
++
+ /* if DBUS_ENABLE_STATS */
+ void _dbus_connection_get_stats (DBusConnection *connection,
+                                  dbus_uint32_t  *in_messages,
+diff --git a/dbus/dbus-connection.c b/dbus/dbus-connection.c
+index 2b2b853..32ede79 100644
+--- a/dbus/dbus-connection.c
++++ b/dbus/dbus-connection.c
+@@ -319,7 +319,8 @@ struct DBusConnection
+    */
+   dbus_bool_t dispatch_acquired; /**< Someone has dispatch path (can drain incoming queue) */
+   dbus_bool_t io_path_acquired;  /**< Someone has transport io path (can use the transport to read/write messages) */
+-  
++
++  unsigned int dispatch_disabled : 1;  /**< if true, then dispatching incoming messages is stopped until enabled again */
+   unsigned int shareable : 1; /**< #TRUE if libdbus owns a reference to the connection and can return it from dbus_connection_open() more than once */
+   
+   unsigned int exit_on_disconnect : 1; /**< If #TRUE, exit after handling disconnect signal */
+@@ -447,6 +448,39 @@ _dbus_connection_wakeup_mainloop (DBusConnection *connection)
+     (*connection->wakeup_main_function) (connection->wakeup_main_data);
+ }
+ 
++static void
++_dbus_connection_set_dispatch(DBusConnection *connection,
++                              dbus_bool_t disabled)
++{
++  CONNECTION_LOCK (connection);
++  if (connection->dispatch_disabled != disabled)
++    {
++      DBusDispatchStatus status;
++
++      connection->dispatch_disabled = disabled;
++      status = _dbus_connection_get_dispatch_status_unlocked (connection);
++      _dbus_connection_update_dispatch_status_and_unlock (connection, status);
++    }
++  else
++    {
++      CONNECTION_UNLOCK (connection);
++    }
++}
++
++
++void
++_dbus_connection_enable_dispatch (DBusConnection *connection)
++{
++  _dbus_connection_set_dispatch (connection, FALSE);
++}
++
++void
++ _dbus_connection_disable_dispatch (DBusConnection *connection)
++{
++  _dbus_connection_set_dispatch (connection, TRUE);
++}
++
++
+ #ifdef DBUS_ENABLE_EMBEDDED_TESTS
+ /**
+  * Gets the locks so we can examine them
+@@ -4094,6 +4128,82 @@ _dbus_connection_putback_message_link_unlocked (DBusConnection *connection,
+       "_dbus_connection_putback_message_link_unlocked");
+ }
+ 
++dbus_bool_t
++_dbus_connection_putback_message (DBusConnection *connection,
++                                  DBusMessage    *after_message,
++                                  DBusMessage    *message,
++                                  DBusError      *error)
++{
++  DBusDispatchStatus status;
++  DBusList *message_link = _dbus_list_alloc_link (message);
++  DBusList *after_link;
++  if (message_link == NULL)
++    {
++      _DBUS_SET_OOM (error);
++      return FALSE;
++    }
++  dbus_message_ref (message);
++
++  CONNECTION_LOCK (connection);
++  _dbus_connection_acquire_dispatch (connection);
++  HAVE_LOCK_CHECK (connection);
++
++  after_link = _dbus_list_find_first(&connection->incoming_messages, after_message);
++  _dbus_list_insert_after_link (&connection->incoming_messages, after_link, message_link);
++  connection->n_incoming += 1;
++
++  _dbus_verbose ("Message %p (%s %s %s '%s') put back into queue %p, %d incoming\n",
++                 message_link->data,
++                 dbus_message_type_to_string (dbus_message_get_type (message_link->data)),
++                 dbus_message_get_interface (message_link->data) ?
++                 dbus_message_get_interface (message_link->data) :
++                 "no interface",
++                 dbus_message_get_member (message_link->data) ?
++                 dbus_message_get_member (message_link->data) :
++                 "no member",
++                 dbus_message_get_signature (message_link->data),
++                 connection, connection->n_incoming);
++
++  _dbus_message_trace_ref (message_link->data, -1, -1,
++      "_dbus_connection_putback_message");
++
++  _dbus_connection_release_dispatch (connection);
++
++  status = _dbus_connection_get_dispatch_status_unlocked (connection);
++  _dbus_connection_update_dispatch_status_and_unlock (connection, status);
++
++  return TRUE;
++}
++
++dbus_bool_t
++_dbus_connection_remove_message (DBusConnection *connection,
++                                 DBusMessage *message)
++{
++  DBusDispatchStatus status;
++  dbus_bool_t removed;
++
++  CONNECTION_LOCK (connection);
++  _dbus_connection_acquire_dispatch (connection);
++  HAVE_LOCK_CHECK (connection);
++
++  removed = _dbus_list_remove(&connection->incoming_messages, message);
++
++  if (removed)
++    {
++      connection->n_incoming -= 1;
++      dbus_message_unref(message);
++      _dbus_verbose ("Message %p removed from incoming queue\n", message);
++    }
++  else
++      _dbus_verbose ("Message %p not found in the incoming queue\n", message);
++
++  _dbus_connection_release_dispatch (connection);
++
++  status = _dbus_connection_get_dispatch_status_unlocked (connection);
++  _dbus_connection_update_dispatch_status_and_unlock (connection, status);
++  return removed;
++}
++
+ /**
+  * Returns the first-received message from the incoming message queue,
+  * removing it from the queue. The caller owns a reference to the
+@@ -4277,8 +4387,9 @@ static DBusDispatchStatus
+ _dbus_connection_get_dispatch_status_unlocked (DBusConnection *connection)
+ {
+   HAVE_LOCK_CHECK (connection);
+-  
+-  if (connection->n_incoming > 0)
++  if (connection->dispatch_disabled && dbus_connection_get_is_connected(connection))
++    return DBUS_DISPATCH_COMPLETE;
++  else if (connection->n_incoming > 0)
+     return DBUS_DISPATCH_DATA_REMAINS;
+   else if (!_dbus_transport_queue_messages (connection->transport))
+     return DBUS_DISPATCH_NEED_MEMORY;
+@@ -4715,6 +4826,8 @@ dbus_connection_dispatch (DBusConnection *connection)
+   
+   CONNECTION_LOCK (connection);
+ 
++  if (result == DBUS_HANDLER_RESULT_LATER)
++      goto out;
+   if (result == DBUS_HANDLER_RESULT_NEED_MEMORY)
+     {
+       _dbus_verbose ("No memory\n");
+@@ -4837,9 +4950,11 @@ dbus_connection_dispatch (DBusConnection *connection)
+                  connection);
+   
+  out:
+-  if (result == DBUS_HANDLER_RESULT_NEED_MEMORY)
++  if (result == DBUS_HANDLER_RESULT_LATER ||
++      result == DBUS_HANDLER_RESULT_NEED_MEMORY)
+     {
+-      _dbus_verbose ("out of memory\n");
++      if (result == DBUS_HANDLER_RESULT_NEED_MEMORY)
++        _dbus_verbose ("out of memory\n");
+       
+       /* Put message back, and we'll start over.
+        * Yes this means handlers must be idempotent if they
+diff --git a/dbus/dbus-list.c b/dbus/dbus-list.c
+index c4c1856..f84918b 100644
+--- a/dbus/dbus-list.c
++++ b/dbus/dbus-list.c
+@@ -459,6 +459,35 @@ _dbus_list_remove_last (DBusList **list,
+ }
+ 
+ /**
++ * Finds a value in the list. Returns the first link
++ * with value equal to the given data pointer.
++ * This is a linear-time operation.
++ * Returns #NULL if no value found that matches.
++ *
++ * @param list address of the list head.
++ * @param data the value to find.
++ * @returns the link if found
++ */
++DBusList*
++_dbus_list_find_first (DBusList **list,
++                       void      *data)
++{
++  DBusList *link;
++
++  link = _dbus_list_get_first_link (list);
++
++  while (link != NULL)
++    {
++      if (link->data == data)
++        return link;
++
++      link = _dbus_list_get_next_link (list, link);
++    }
++
++  return NULL;
++}
++
++/**
+  * Finds a value in the list. Returns the last link
+  * with value equal to the given data pointer.
+  * This is a linear-time operation.
+diff --git a/dbus/dbus-list.h b/dbus/dbus-list.h
+index 910d738..abe8331 100644
+--- a/dbus/dbus-list.h
++++ b/dbus/dbus-list.h
+@@ -59,6 +59,8 @@ dbus_bool_t _dbus_list_remove_last        (DBusList **list,
+                                            void      *data);
+ void        _dbus_list_remove_link        (DBusList **list,
+                                            DBusList  *link);
++DBusList*   _dbus_list_find_first         (DBusList **list,
++                                           void      *data);
+ DBusList*   _dbus_list_find_last          (DBusList **list,
+                                            void      *data);
+ void        _dbus_list_clear              (DBusList **list);
+diff --git a/dbus/dbus-shared.h b/dbus/dbus-shared.h
+index 6a57670..5371d88 100644
+--- a/dbus/dbus-shared.h
++++ b/dbus/dbus-shared.h
+@@ -67,7 +67,8 @@ typedef enum
+ {
+   DBUS_HANDLER_RESULT_HANDLED,         /**< Message has had its effect - no need to run more handlers. */ 
+   DBUS_HANDLER_RESULT_NOT_YET_HANDLED, /**< Message has not had any effect - see if other handlers want it. */
+-  DBUS_HANDLER_RESULT_NEED_MEMORY      /**< Need more memory in order to return #DBUS_HANDLER_RESULT_HANDLED or #DBUS_HANDLER_RESULT_NOT_YET_HANDLED. Please try again later with more memory. */
++  DBUS_HANDLER_RESULT_NEED_MEMORY,     /**< Need more memory in order to return #DBUS_HANDLER_RESULT_HANDLED or #DBUS_HANDLER_RESULT_NOT_YET_HANDLED. Please try again later with more memory. */
++  DBUS_HANDLER_RESULT_LATER            /**< Message dispatch deferred due to pending policy check */
+ } DBusHandlerResult;
+ 
+ /* Bus names */
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0008-Handle-receive-rule-result-unavailability-and-messag.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0008-Handle-receive-rule-result-unavailability-and-messag.patch
@@ -1,0 +1,1106 @@
+From b3b24719abfbde772516fed12d148f3e483f19d7 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Fri, 28 Nov 2014 12:39:33 +0100
+Subject: [PATCH 08/13] Handle receive rule result unavailability and message
+ broadcasts
+
+When message is sent to the addressed recipient and receive rule
+result is unavailable we don't want to block the sender
+as it most likely will be the privileged service, so instead we queue
+it at the recipient. Any further messages sent to it will be queued to
+maintain message order. Once the answer from Cynara arrives messages are
+dispatched from the recipient queue. In such case full dispatch is
+performed - messages are sent to addressed recipient and other
+interested connections.
+Messages sent to non-addressed recipients (eavesdroppers or broadcast
+message recipients) are handled in a similar way. The difference is
+that it is not full dispatch meaning message is sent to a single recipient.
+
+Change-Id: Iecd5395f75a4c7811fa97247a37d8fc4d42e8814
+---
+ bus/activation.c |   4 +-
+ bus/bus.c        |  51 +++++++--
+ bus/bus.h        |  19 ++++
+ bus/check.c      | 311 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ bus/check.h      |  25 +++++
+ bus/connection.c | 167 +++++++++++++++++++++++++++--
+ bus/connection.h |  19 +++-
+ bus/dispatch.c   | 158 +++++++++++++++++++++-------
+ bus/dispatch.h   |  11 +-
+ bus/driver.c     |   2 +-
+ bus/policy.c     |   6 ++
+ 11 files changed, 709 insertions(+), 64 deletions(-)
+
+diff --git a/bus/activation.c b/bus/activation.c
+index 0722384..be2bc40 100644
+--- a/bus/activation.c
++++ b/bus/activation.c
+@@ -1197,7 +1197,7 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+           switch (bus_dispatch_matches (transaction,
+                                         entry->connection,
+                                         addressed_recipient,
+-                                        entry->activation_message, &error))
++                                        entry->activation_message, NULL, &error))
+             {
+             case BUS_RESULT_TRUE:
+               break;
+@@ -2070,7 +2070,7 @@ bus_activation_activate_service (BusActivation  *activation,
+                                entry->systemd_service);
+               /* Wonderful, systemd is connected, let's just send the msg */
+               switch (bus_dispatch_matches (activation_transaction, NULL, bus_service_get_primary_owners_connection (service),
+-                                            message, error))
++                                            message, NULL, error))
+                 {
+                 case BUS_RESULT_TRUE:
+                   retval = TRUE;
+diff --git a/bus/bus.c b/bus/bus.c
+index 1fc9238..6d51b0b 100644
+--- a/bus/bus.c
++++ b/bus/bus.c
+@@ -1708,17 +1708,9 @@ bus_context_check_security_policy (BusContext          *context,
+   }
+ 
+   /* See if limits on size have been exceeded */
+-  if (proposed_recipient &&
+-      ((dbus_connection_get_outgoing_size (proposed_recipient) > context->limits.max_outgoing_bytes) ||
+-       (dbus_connection_get_outgoing_unix_fds (proposed_recipient) > context->limits.max_outgoing_unix_fds)))
+-    {
+-      complain_about_message (context, DBUS_ERROR_LIMITS_EXCEEDED,
+-          "Rejected: destination has a full message queue",
+-          0, message, sender, proposed_recipient, requested_reply, TRUE, NULL,
+-          error);
+-      _dbus_verbose ("security policy disallowing message due to full message queue\n");
++  if (!bus_context_check_recipient_message_limits(context, proposed_recipient, sender, message,
++      requested_reply, error))
+       return BUS_RESULT_FALSE;
+-    }
+ 
+   /* Record that we will allow a reply here in the future (don't
+    * bother if the recipient is the bus or this is an eavesdropping
+@@ -1773,3 +1765,42 @@ bus_context_check_all_watches (BusContext *context)
+       _dbus_server_toggle_all_watches (server, enabled);
+     }
+ }
++
++void
++bus_context_complain_about_message (BusContext     *context,
++                                    const char     *error_name,
++                                    const char     *complaint,
++                                    int             matched_rules,
++                                    DBusMessage    *message,
++                                    DBusConnection *sender,
++                                    DBusConnection *proposed_recipient,
++                                    dbus_bool_t     requested_reply,
++                                    dbus_bool_t     log,
++                                    const char     *privilege,
++                                    DBusError      *error)
++{
++  complain_about_message(context, error_name, complaint, matched_rules, message, sender,
++      proposed_recipient, requested_reply, log, privilege, error);
++}
++
++dbus_bool_t   bus_context_check_recipient_message_limits (BusContext *context,
++                                                          DBusConnection *recipient,
++                                                          DBusConnection *sender,
++                                                          DBusMessage *message,
++                                                          dbus_bool_t requested_reply,
++                                                          DBusError *error)
++
++{
++  if (recipient &&
++       ((dbus_connection_get_outgoing_size (recipient) > context->limits.max_outgoing_bytes) ||
++        (dbus_connection_get_outgoing_unix_fds (recipient) > context->limits.max_outgoing_unix_fds)))
++     {
++       complain_about_message (context, DBUS_ERROR_LIMITS_EXCEEDED,
++           "Rejected: destination has a full message queue",
++           0, message, sender, recipient, requested_reply, TRUE, NULL,
++           error);
++       _dbus_verbose ("security policy disallowing message due to full message queue\n");
++       return FALSE;
++     }
++  return TRUE;
++}
+diff --git a/bus/bus.h b/bus/bus.h
+index 040e3c7..54de1af 100644
+--- a/bus/bus.h
++++ b/bus/bus.h
+@@ -151,4 +151,23 @@ BusResult         bus_context_check_security_policy              (BusContext
+                                                                   BusDeferredMessage **deferred_message);
+ void              bus_context_check_all_watches                  (BusContext       *context);
+ 
++dbus_bool_t       bus_context_check_recipient_message_limits     (BusContext *context,
++                                                                  DBusConnection *recipient,
++                                                                  DBusConnection *sender,
++                                                                  DBusMessage *message,
++                                                                  dbus_bool_t requested_reply,
++                                                                  DBusError *error);
++void              bus_context_complain_about_message             (BusContext     *context,
++                                                                  const char     *error_name,
++                                                                  const char     *complaint,
++                                                                  int             matched_rules,
++                                                                  DBusMessage    *message,
++                                                                  DBusConnection *sender,
++                                                                  DBusConnection *proposed_recipient,
++                                                                  dbus_bool_t     requested_reply,
++                                                                  dbus_bool_t     log,
++                                                                  const char     *privilege,
++                                                                  DBusError      *error);
++
++
+ #endif /* BUS_BUS_H */
+diff --git a/bus/check.c b/bus/check.c
+index a5dbaff..baff981 100644
+--- a/bus/check.c
++++ b/bus/check.c
+@@ -49,6 +49,9 @@ typedef struct BusDeferredMessage
+   DBusConnection *sender;
+   DBusConnection *proposed_recipient;
+   DBusConnection *addressed_recipient;
++  dbus_bool_t requested_reply;
++  int matched_rules;
++  const char *privilege;
+   dbus_bool_t full_dispatch;
+   BusDeferredMessageStatus status;
+   BusResult response;
+@@ -122,6 +125,89 @@ bus_check_enable_dispatch_callback (BusDeferredMessage *deferred_message,
+   _dbus_connection_enable_dispatch(deferred_message->sender);
+ }
+ 
++static void
++bus_check_queued_message_reply_callback (BusDeferredMessage *deferred_message,
++                                         BusResult result)
++{
++  int status;
++
++  _dbus_verbose("bus_check_queued_message_reply_callback called message=%p\n", deferred_message);
++
++  if (!bus_connection_is_active(deferred_message->proposed_recipient))
++    return;
++
++  status = deferred_message->status;
++
++  deferred_message->status = 0; /* mark message as not waiting for response */
++  deferred_message->response = result;
++
++  /*
++   * If send rule allows us to send message we still need to check receive rules.
++   */
++  if ((status & BUS_DEFERRED_MESSAGE_CHECK_SEND) && (result == BUS_RESULT_TRUE))
++    {
++      int toggles;
++      BusContext *context;
++      BusRegistry *registry;
++      BusClientPolicy *recipient_policy;
++      BusDeferredMessage *deferred_message_receive;
++
++      context = bus_connection_get_context(deferred_message->proposed_recipient);
++      registry = bus_context_get_registry(context);
++      recipient_policy = bus_connection_get_policy(deferred_message->proposed_recipient);
++
++      deferred_message->response = bus_client_policy_check_can_receive(recipient_policy, registry,
++          deferred_message->requested_reply, deferred_message->sender,
++          deferred_message->addressed_recipient, deferred_message->proposed_recipient, deferred_message->message,
++          &toggles, NULL, &deferred_message_receive);
++      if (deferred_message->response == BUS_RESULT_LATER)
++        {
++          /* replace deferred message associated with send check with the one associated with
++           * receive check */
++          if (!bus_deferred_message_replace(deferred_message, deferred_message_receive))
++            {
++              /* failed to replace deferred message (due to oom). Set it to rejected */
++              deferred_message->response = BUS_RESULT_FALSE;
++            }
++        }
++    }
++
++  bus_connection_dispatch_deferred(deferred_message->proposed_recipient);
++}
++
++static void
++queue_deferred_message_cancel_transaction_hook (void *data)
++{
++  BusDeferredMessage *deferred_message = (BusDeferredMessage *)data;
++  bus_connection_remove_deferred_message(deferred_message->proposed_recipient, deferred_message);
++}
++
++
++dbus_bool_t
++bus_deferred_message_queue_at_recipient (BusDeferredMessage *deferred_message,
++                                         BusTransaction *transaction,
++                                         dbus_bool_t full_dispatch,
++                                         dbus_bool_t prepend)
++{
++  _dbus_assert(deferred_message != NULL);
++  _dbus_assert(deferred_message->proposed_recipient != NULL);
++
++  if (!bus_connection_queue_deferred_message(deferred_message->proposed_recipient,
++         deferred_message, prepend))
++    return FALSE;
++
++  if (!bus_transaction_add_cancel_hook(transaction, queue_deferred_message_cancel_transaction_hook,
++      deferred_message, NULL))
++    {
++      bus_connection_remove_deferred_message(deferred_message->proposed_recipient, deferred_message);
++      return FALSE;
++    }
++  deferred_message->response_callback = bus_check_queued_message_reply_callback;
++  deferred_message->full_dispatch = full_dispatch;
++
++  return TRUE;
++}
++
+ void
+ bus_deferred_message_disable_sender (BusDeferredMessage *deferred_message)
+ {
+@@ -132,6 +218,20 @@ bus_deferred_message_disable_sender (BusDeferredMessage *deferred_message)
+   deferred_message->response_callback = bus_check_enable_dispatch_callback;
+ }
+ 
++void
++bus_deferred_message_set_policy_check_info (BusDeferredMessage *deferred_message,
++                                            dbus_bool_t requested_reply,
++                                            int matched_rules,
++                                            const char *privilege)
++{
++  _dbus_assert(deferred_message != NULL);
++
++  deferred_message->requested_reply = requested_reply;
++  deferred_message->matched_rules = matched_rules;
++  deferred_message->privilege = privilege;
++}
++
++
+ #ifdef DBUS_ENABLE_EMBEDDED_TESTS
+ dbus_bool_t (*bus_check_test_override) (DBusConnection *connection,
+                                         const char *privilege);
+@@ -196,6 +296,9 @@ BusDeferredMessage *bus_deferred_message_new (DBusMessage *message,
+   deferred_message->addressed_recipient = addressed_recipient != NULL ? dbus_connection_ref(addressed_recipient) : NULL;
+   deferred_message->proposed_recipient = proposed_recipient != NULL ? dbus_connection_ref(proposed_recipient) : NULL;
+   deferred_message->message = dbus_message_ref(message);
++  deferred_message->requested_reply = FALSE;
++  deferred_message->matched_rules = 0;
++  deferred_message->privilege = NULL;
+   deferred_message->response = response;
+   deferred_message->status = 0;
+   deferred_message->full_dispatch = FALSE;
+@@ -232,12 +335,219 @@ bus_deferred_message_unref (BusDeferredMessage *deferred_message)
+      }
+ }
+ 
++dbus_bool_t
++bus_deferred_message_check_message_limits (BusDeferredMessage *deferred_message, DBusError *error)
++{
++  BusContext *context = bus_connection_get_context(deferred_message->proposed_recipient);
++
++  return bus_context_check_recipient_message_limits(context, deferred_message->proposed_recipient,
++      deferred_message->sender, deferred_message->message, deferred_message->requested_reply,
++      error);
++}
++
++dbus_bool_t
++bus_deferred_message_expect_method_reply(BusDeferredMessage *deferred_message, BusTransaction *transaction, DBusError *error)
++{
++  int type = dbus_message_get_type(deferred_message->message);
++  if (type == DBUS_MESSAGE_TYPE_METHOD_CALL &&
++        deferred_message->sender &&
++        deferred_message->addressed_recipient &&
++        deferred_message->addressed_recipient == deferred_message->proposed_recipient && /* not eavesdropping */
++        !bus_connections_expect_reply (bus_connection_get_connections (deferred_message->sender),
++                                       transaction,
++                                       deferred_message->sender, deferred_message->addressed_recipient,
++                                       deferred_message->message, error))
++    {
++      _dbus_verbose ("Failed to record reply expectation or problem with the message expecting a reply\n");
++      return FALSE;
++    }
++  return TRUE;
++}
++
++void
++bus_deferred_message_create_error(BusDeferredMessage *deferred_message,
++    const char *error_message, DBusError *error)
++{
++  BusContext *context;
++  _dbus_assert (deferred_message->status == 0 && deferred_message->response == BUS_RESULT_FALSE);
++
++  if (deferred_message->sender == NULL)
++    return; /* error won't be sent to bus driver anyway */
++
++  context = bus_connection_get_context(deferred_message->sender);
++  bus_context_complain_about_message(context, DBUS_ERROR_ACCESS_DENIED, "Rejected message",
++      deferred_message->matched_rules, deferred_message->message, deferred_message->sender,
++      deferred_message->proposed_recipient, deferred_message->requested_reply, FALSE,
++      deferred_message->privilege, error);
++}
++
++BusResult
++bus_deferred_message_dispatch (BusDeferredMessage *deferred_message)
++{
++  BusContext *context = bus_connection_get_context (deferred_message->proposed_recipient);
++  BusTransaction *transaction = bus_transaction_new (context);
++  BusResult result = BUS_RESULT_TRUE;
++  DBusError error;
++
++  if (transaction == NULL)
++    {
++      return BUS_RESULT_FALSE;
++    }
++
++  dbus_error_init(&error);
++
++  if (!deferred_message->full_dispatch)
++    {
++      result = deferred_message->response;
++      switch (result)
++        {
++        case BUS_RESULT_TRUE:
++          if (!bus_context_check_recipient_message_limits(context, deferred_message->proposed_recipient,
++               deferred_message->sender, deferred_message->message, deferred_message->requested_reply, &error))
++              result = BUS_RESULT_FALSE;
++          break;
++        case BUS_RESULT_FALSE:
++          break;
++        case BUS_RESULT_LATER:
++          {
++            BusDeferredMessage *deferred_message2;
++            result = bus_context_check_security_policy (context, transaction,
++                                                        deferred_message->sender,
++                                                        deferred_message->addressed_recipient,
++                                                        deferred_message->proposed_recipient,
++                                                        deferred_message->message, NULL,
++                                                        &deferred_message2);
++
++            if (result == BUS_RESULT_LATER)
++              {
++                /* prepend at recipient */
++                if (!bus_deferred_message_queue_at_recipient(deferred_message2, transaction,
++                    FALSE, TRUE))
++                  result = BUS_RESULT_FALSE;
++              }
++          }
++        }
++
++      /* silently drop messages on access denial */
++      if (result == BUS_RESULT_TRUE)
++        {
++          if (!bus_transaction_send (transaction, deferred_message->proposed_recipient, deferred_message->message, TRUE))
++            result = BUS_RESULT_FALSE;
++        }
++
++      bus_transaction_execute_and_free(transaction);
++
++      goto out;
++    }
++
++  /* do not attempt to send message if sender has disconnected */
++  if (deferred_message->sender != NULL && !bus_connection_is_active(deferred_message->sender))
++    {
++      bus_transaction_cancel_and_free(transaction);
++      result = BUS_RESULT_FALSE;
++      goto out;
++    }
++
++  result = bus_dispatch_matches(transaction, deferred_message->sender,
++      deferred_message->addressed_recipient, deferred_message->message, deferred_message, &error);
++
++  if (result == BUS_RESULT_LATER)
++    {
++      /* Message deferring was already done in bus_dispatch_matches */
++      bus_transaction_cancel_and_free(transaction);
++      goto out;
++    }
++
++  /* this part is a copy & paste from bus_dispatch function. Probably can be moved to a function */
++  if (dbus_error_is_set (&error))
++    {
++      if (!dbus_connection_get_is_connected (deferred_message->sender))
++        {
++          /* If we disconnected it, we won't bother to send it any error
++           * messages.
++           */
++          _dbus_verbose ("Not sending error to connection we disconnected\n");
++        }
++      else if (dbus_error_has_name (&error, DBUS_ERROR_NO_MEMORY))
++        {
++          bus_connection_send_oom_error (deferred_message->sender, deferred_message->message);
++
++          /* cancel transaction due to OOM */
++          if (transaction != NULL)
++            {
++              bus_transaction_cancel_and_free (transaction);
++              transaction = NULL;
++            }
++        }
++      else
++        {
++          /* Try to send the real error, if no mem to do that, send
++           * the OOM error
++           */
++          _dbus_assert (transaction != NULL);
++          if (!bus_transaction_send_error_reply (transaction, deferred_message->sender,
++                                                 &error, deferred_message->message))
++            {
++              bus_connection_send_oom_error (deferred_message->sender, deferred_message->message);
++
++              /* cancel transaction due to OOM */
++              if (transaction != NULL)
++                {
++                  bus_transaction_cancel_and_free (transaction);
++                  transaction = NULL;
++                }
++            }
++        }
++    }
++
++  if (transaction != NULL)
++    {
++      bus_transaction_execute_and_free (transaction);
++    }
++
++out:
++  dbus_error_free(&error);
++
++  return result;
++}
++
++dbus_bool_t
++bus_deferred_message_replace (BusDeferredMessage *old_message, BusDeferredMessage *new_message)
++{
++  if (bus_connection_replace_deferred_message(old_message->proposed_recipient,
++        old_message, new_message))
++    {
++      new_message->response_callback = old_message->response_callback;
++      new_message->full_dispatch = old_message->full_dispatch;
++      return TRUE;
++    }
++  return FALSE;
++}
++
++dbus_bool_t
++bus_deferred_message_waits_for_check(BusDeferredMessage *deferred_message)
++{
++  return deferred_message->status != 0;
++}
++
++DBusConnection *
++bus_deferred_message_get_recipient(BusDeferredMessage *deferred_message)
++{
++  return deferred_message->proposed_recipient;
++}
++
+ BusDeferredMessageStatus
+ bus_deferred_message_get_status (BusDeferredMessage *deferred_message)
+ {
+   return deferred_message->status;
+ }
+ 
++BusResult
++bus_deferred_message_get_response (BusDeferredMessage *deferred_message)
++{
++  return deferred_message->response;
++}
++
+ void
+ bus_deferred_message_response_received (BusDeferredMessage *deferred_message,
+                                         BusResult result)
+@@ -247,3 +557,4 @@ bus_deferred_message_response_received (BusDeferredMessage *deferred_message,
+       deferred_message->response_callback(deferred_message, result);
+     }
+ }
++
+diff --git a/bus/check.h b/bus/check.h
+index f381789..3c6b2a1 100644
+--- a/bus/check.h
++++ b/bus/check.h
+@@ -64,12 +64,37 @@ BusDeferredMessage *bus_deferred_message_new                (DBusMessage *messag
+ 
+ BusDeferredMessage *bus_deferred_message_ref                (BusDeferredMessage *deferred_message);
+ void                bus_deferred_message_unref              (BusDeferredMessage *deferred_message);
++BusResult           bus_deferred_message_dispatch           (BusDeferredMessage *deferred_message);
++dbus_bool_t         bus_deferred_message_waits_for_check    (BusDeferredMessage *deferred_message);
++DBusConnection     *bus_deferred_message_get_recipient      (BusDeferredMessage *deferred_message);
+ void                bus_deferred_message_response_received  (BusDeferredMessage *deferred_message,
+                                                              BusResult result);
++dbus_bool_t         bus_deferred_message_queue_at_recipient (BusDeferredMessage *deferred_message,
++                                                             BusTransaction *transaction,
++                                                             dbus_bool_t full_dispatch,
++                                                             dbus_bool_t prepend);
++dbus_bool_t         bus_deferred_message_replace            (BusDeferredMessage *old_message,
++                                                             BusDeferredMessage *new_message);
+ void                bus_deferred_message_disable_sender     (BusDeferredMessage *deferred_message);
++BusResult           bus_deferred_message_get_response       (BusDeferredMessage *deferred_message);
+ 
+ BusDeferredMessageStatus  bus_deferred_message_get_status   (BusDeferredMessage *deferred_message);
+ 
++
++dbus_bool_t         bus_deferred_message_expect_method_reply (BusDeferredMessage *deferred_message,
++                                                              BusTransaction *transaction,
++                                                              DBusError *error);
++void                bus_deferred_message_create_error        (BusDeferredMessage *deferred_message,
++                                                              const char *error_message,
++                                                              DBusError *error);
++void                bus_deferred_message_set_policy_check_info (BusDeferredMessage *deferred_message,
++                                                                dbus_bool_t requested_reply,
++                                                                int matched_rules,
++                                                                const char *privilege);
++dbus_bool_t         bus_deferred_message_check_message_limits (BusDeferredMessage *deferred_message,
++                                                               DBusError *error);
++
++
+ #ifdef DBUS_ENABLE_EMBEDDED_TESTS
+ extern dbus_bool_t (*bus_check_test_override) (DBusConnection *connection,
+                                                const char *privilege);
+diff --git a/bus/connection.c b/bus/connection.c
+index 12d8147..3f50e90 100644
+--- a/bus/connection.c
++++ b/bus/connection.c
+@@ -30,10 +30,12 @@
+ #include "signals.h"
+ #include "expirelist.h"
+ #include "selinux.h"
++#include "check.h"
+ #include <dbus/dbus-list.h>
+ #include <dbus/dbus-hash.h>
+ #include <dbus/dbus-timeout.h>
+ #include <dbus/dbus-connection-internal.h>
++#include <dbus/dbus-message-internal.h>
+ #ifdef DBUS_ENABLE_CYNARA
+ #include <stdlib.h>
+ #include <cynara-session.h>
+@@ -95,6 +97,7 @@ typedef struct
+   DBusMessage *oom_message;
+   DBusPreallocatedSend *oom_preallocated;
+   BusClientPolicy *policy;
++  DBusList *deferred_messages;  /**< Queue of messages deferred due to pending policy check */
+ 
+   char *cached_loginfo_string;
+   BusSELinuxID *selinux_id;
+@@ -256,6 +259,8 @@ bus_connection_disconnected (DBusConnection *connection)
+       bus_transaction_execute_and_free (transaction);
+     }
+ 
++  bus_connection_clear_deferred_messages(connection);
++
+   bus_dispatch_remove_connection (connection);
+   
+   /* no more watching */
+@@ -2123,6 +2128,7 @@ bus_transaction_send_from_driver (BusTransaction *transaction,
+                                   DBusConnection *connection,
+                                   DBusMessage    *message)
+ {
++  BusDeferredMessage *deferred_message;
+   /* We have to set the sender to the driver, and have
+    * to check security policy since it was not done in
+    * dispatch.c
+@@ -2154,7 +2160,7 @@ bus_transaction_send_from_driver (BusTransaction *transaction,
+   switch (bus_context_check_security_policy (bus_transaction_get_context (transaction),
+                                              transaction,
+                                              NULL, connection, connection, message, NULL,
+-                                             NULL))
++                                             &deferred_message))
+     {
+     case BUS_RESULT_TRUE:
+       break;
+@@ -2162,18 +2168,19 @@ bus_transaction_send_from_driver (BusTransaction *transaction,
+       return TRUE;
+       break;
+     case BUS_RESULT_LATER:
+-      _dbus_verbose ("Cannot delay sending message from bus driver, dropping it\n");
+-      return TRUE;
+-      break;
++      if (!bus_deferred_message_queue_at_recipient(deferred_message, transaction, FALSE, FALSE))
++          return FALSE;
++      return TRUE; /* pretend to have sent it */
+     }
+ 
+-  return bus_transaction_send (transaction, connection, message);
++  return bus_transaction_send (transaction, connection, message, FALSE);
+ }
+ 
+ dbus_bool_t
+ bus_transaction_send (BusTransaction *transaction,
+                       DBusConnection *connection,
+-                      DBusMessage    *message)
++                      DBusMessage    *message,
++                      dbus_bool_t     deferred_dispatch)
+ {
+   MessageToSend *to_send;
+   BusConnectionData *d;
+@@ -2199,7 +2206,28 @@ bus_transaction_send (BusTransaction *transaction,
+   
+   d = BUS_CONNECTION_DATA (connection);
+   _dbus_assert (d != NULL);
+-  
++
++  if (!deferred_dispatch && d->deferred_messages != NULL)
++    {
++      BusDeferredMessage *deferred_message;
++      dbus_bool_t success;
++      /* sender and addressed recipient are not required at this point as we only need to send message
++       * to a single recipient without performing policy check. */
++      deferred_message = bus_deferred_message_new (message,
++                                                   NULL,
++                                                   NULL,
++                                                   connection,
++                                                   BUS_RESULT_TRUE);
++      if (deferred_message == NULL)
++        return FALSE;
++
++      success = bus_deferred_message_queue_at_recipient(deferred_message, transaction,
++          FALSE, FALSE);
++      bus_deferred_message_unref(deferred_message);
++
++      return success;
++    }
++
+   to_send = dbus_new (MessageToSend, 1);
+   if (to_send == NULL)
+     {
+@@ -2451,6 +2479,131 @@ bus_transaction_add_cancel_hook (BusTransaction               *transaction,
+   return TRUE;
+ }
+ 
++void
++bus_connection_dispatch_deferred (DBusConnection *connection)
++{
++  BusDeferredMessage *message;
++
++  _dbus_return_if_fail (connection != NULL);
++
++  while ((message = bus_connection_pop_deferred_message(connection)) != NULL)
++    {
++      bus_deferred_message_dispatch(message);
++      bus_deferred_message_unref(message);
++    }
++}
++
++dbus_bool_t
++bus_connection_has_deferred_messages (DBusConnection *connection)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++  return d->deferred_messages != NULL ? TRUE : FALSE;
++}
++
++dbus_bool_t
++bus_connection_queue_deferred_message (DBusConnection *connection,
++                                       BusDeferredMessage *message,
++                                       dbus_bool_t prepend)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++  dbus_bool_t success;
++  if (prepend)
++    success = _dbus_list_prepend(&d->deferred_messages, message);
++  else
++    success = _dbus_list_append(&d->deferred_messages, message);
++
++  if (success)
++    {
++      bus_deferred_message_ref(message);
++      return TRUE;
++    }
++
++  return FALSE;
++}
++
++dbus_bool_t
++bus_connection_replace_deferred_message (DBusConnection *connection,
++                                         BusDeferredMessage *oldMessage,
++                                         BusDeferredMessage *newMessage)
++{
++  DBusList *link;
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++
++  link = _dbus_list_find_first(&d->deferred_messages, oldMessage);
++  if (link == NULL)
++    return FALSE;
++
++  if (!_dbus_list_insert_after(&d->deferred_messages, link, newMessage))
++    return FALSE;
++
++  bus_deferred_message_ref(newMessage);
++  _dbus_list_remove_link(&d->deferred_messages, link);
++  bus_deferred_message_unref(oldMessage);
++  return TRUE;
++}
++
++BusDeferredMessage *
++bus_connection_pop_deferred_message (DBusConnection *connection)
++{
++  DBusList *link;
++  BusDeferredMessage *message;
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++
++  link =_dbus_list_get_first_link(&d->deferred_messages);
++  if (link != NULL)
++    {
++      message = link->data;
++      if (!bus_deferred_message_waits_for_check(message))
++        {
++          _dbus_list_remove_link(&d->deferred_messages, link);
++          return message;
++        }
++    }
++
++  return NULL;
++}
++
++dbus_bool_t
++bus_connection_putback_deferred_message (DBusConnection *connection, BusDeferredMessage *message)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++  if (_dbus_list_prepend(&d->deferred_messages, message))
++    {
++      return TRUE;
++    }
++  return FALSE;
++}
++
++void
++bus_connection_clear_deferred_messages (DBusConnection *connection)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++  DBusList *link;
++  DBusList *next;
++  BusDeferredMessage *message;
++
++  link =_dbus_list_get_first_link(&d->deferred_messages);
++  while (link != NULL)
++    {
++      next = _dbus_list_get_next_link (&d->deferred_messages, link);
++      message = link->data;
++
++      bus_deferred_message_unref(message);
++      _dbus_list_remove_link(&d->deferred_messages, link);
++
++      link = next;
++    }
++}
++
++void
++bus_connection_remove_deferred_message (DBusConnection *connection,
++                                        BusDeferredMessage *message)
++{
++  BusConnectionData *d = BUS_CONNECTION_DATA(connection);
++  if (_dbus_list_remove(&d->deferred_messages, message))
++    bus_deferred_message_unref(message);
++}
++
+ int
+ bus_connections_get_n_active (BusConnections *connections)
+ {
+diff --git a/bus/connection.h b/bus/connection.h
+index 7433746..8d49b25 100644
+--- a/bus/connection.h
++++ b/bus/connection.h
+@@ -82,6 +82,22 @@ dbus_bool_t bus_connection_preallocate_oom_error (DBusConnection *connection);
+ void        bus_connection_send_oom_error        (DBusConnection *connection,
+                                                   DBusMessage    *in_reply_to);
+ 
++dbus_bool_t         bus_connection_has_deferred_messages    (DBusConnection *connection);
++dbus_bool_t         bus_connection_queue_deferred_message   (DBusConnection *connection,
++                                                             BusDeferredMessage *message,
++                                                             dbus_bool_t prepend);
++BusDeferredMessage *bus_connection_pop_deferred_message     (DBusConnection *connection);
++dbus_bool_t         bus_connection_putback_deferred_message (DBusConnection *connection,
++                                                             BusDeferredMessage *message);
++void                bus_connection_remove_deferred_message  (DBusConnection *connection,
++                                                             BusDeferredMessage *message);
++dbus_bool_t         bus_connection_replace_deferred_message (DBusConnection *connection,
++                                                             BusDeferredMessage *oldMessage,
++                                                             BusDeferredMessage *newMessage);
++void                bus_connection_dispatch_deferred        (DBusConnection *connection);
++void                bus_connection_clear_deferred_messages  (DBusConnection *connection);
++
++
+ /* called by signals.c */
+ dbus_bool_t bus_connection_add_match_rule      (DBusConnection *connection,
+                                                 BusMatchRule   *rule);
+@@ -129,7 +145,8 @@ BusTransaction* bus_transaction_new              (BusContext                   *
+ BusContext*     bus_transaction_get_context      (BusTransaction               *transaction);
+ dbus_bool_t     bus_transaction_send             (BusTransaction               *transaction,
+                                                   DBusConnection               *connection,
+-                                                  DBusMessage                  *message);
++                                                  DBusMessage                  *message,
++                                                  dbus_bool_t                   deferred_dispatch);
+ dbus_bool_t     bus_transaction_send_from_driver (BusTransaction               *transaction,
+                                                   DBusConnection               *connection,
+                                                   DBusMessage                  *message);
+diff --git a/bus/dispatch.c b/bus/dispatch.c
+index bb81cc0..143ff3f 100644
+--- a/bus/dispatch.c
++++ b/bus/dispatch.c
+@@ -33,8 +33,10 @@
+ #include "utils.h"
+ #include "bus.h"
+ #include "signals.h"
++#include "dispatch.h"
+ #include "test.h"
+ #include <dbus/dbus-internals.h>
++#include <dbus/dbus-connection-internal.h>
+ #include <dbus/dbus-misc.h>
+ #include <string.h>
+ 
+@@ -63,16 +65,26 @@ send_one_message (DBusConnection *connection,
+   result = bus_context_check_security_policy (context, transaction, sender, addressed_recipient,
+       connection, message, NULL, &deferred_message);
+ 
+-  if (result != BUS_RESULT_TRUE)
++  if (result == BUS_RESULT_FALSE)
+       return TRUE; /* silently don't send it */
+ 
+   if (dbus_message_contains_unix_fds(message) &&
+       !dbus_connection_can_send_type(connection, DBUS_TYPE_UNIX_FD))
+     return TRUE; /* silently don't send it */
+ 
++  if (result == BUS_RESULT_LATER)
++    {
++      if (!bus_deferred_message_queue_at_recipient(deferred_message, transaction, FALSE, FALSE))
++        {
++          BUS_SET_OOM (error);
++          return FALSE;
++        }
++      return TRUE; /* pretend to have sent it */
++    }
++
+   if (!bus_transaction_send (transaction,
+                              connection,
+-                             message))
++                             message, FALSE))
+     {
+       BUS_SET_OOM (error);
+       return FALSE;
+@@ -82,11 +94,12 @@ send_one_message (DBusConnection *connection,
+ }
+ 
+ BusResult
+-bus_dispatch_matches (BusTransaction *transaction,
+-                      DBusConnection *sender,
+-                      DBusConnection *addressed_recipient,
+-                      DBusMessage    *message,
+-                      DBusError      *error)
++bus_dispatch_matches (BusTransaction     *transaction,
++                      DBusConnection     *sender,
++                      DBusConnection     *addressed_recipient,
++                      DBusMessage        *message,
++                      BusDeferredMessage *dispatched_deferred_message,
++                      DBusError          *error)
+ {
+   DBusError tmp_error;
+   BusConnections *connections;
+@@ -110,39 +123,107 @@ bus_dispatch_matches (BusTransaction *transaction,
+   /* First, send the message to the addressed_recipient, if there is one. */
+   if (addressed_recipient != NULL)
+     {
+-      switch (bus_context_check_security_policy (context, transaction,
+-                                                 sender, addressed_recipient,
+-                                                 addressed_recipient,
+-                                                 message, error,
+-                                                 &deferred_message))
++      BusResult result;
++      /* To maintain message order message needs to be appended at the recipient if there are already
++       *  deferred messages and we are not doing deferred dispatch
++       */
++      if (dispatched_deferred_message == NULL && bus_connection_has_deferred_messages(addressed_recipient))
+         {
+-          case BUS_RESULT_TRUE:
+-            break;
+-          case BUS_RESULT_FALSE:
+-            return BUS_RESULT_FALSE;
+-          case BUS_RESULT_LATER:
++          deferred_message = bus_deferred_message_new(message, sender,
++              addressed_recipient, addressed_recipient, BUS_RESULT_LATER);
++
++          if (deferred_message == NULL)
+             {
+-              BusDeferredMessageStatus status;
+-              status = bus_deferred_message_get_status(deferred_message);
++              BUS_SET_OOM(error);
++              return BUS_RESULT_FALSE;
++            }
+ 
+-              if (status & BUS_DEFERRED_MESSAGE_CHECK_SEND)
+-                {
+-                  /* send rule result not available - disable dispatching messages from the sender */
+-                  bus_deferred_message_disable_sender(deferred_message);
+-                  return BUS_RESULT_LATER;
+-                }
+-              else if (status & BUS_DEFERRED_MESSAGE_CHECK_RECEIVE)
+-                {
+-                   dbus_set_error (error, DBUS_ERROR_ACCESS_DENIED,
+-                              "Rejecting message because time is needed to check security policy");
+-                   return BUS_RESULT_FALSE;
+-                }
+-              else
+-                {
+-                  _dbus_verbose("deferred message has no status field set to send or receive unexpectedly\n");
+-                  return BUS_RESULT_FALSE;
+-                }
++          if (!bus_deferred_message_queue_at_recipient(deferred_message, transaction, TRUE, FALSE))
++            {
++              bus_deferred_message_unref(deferred_message);
++              BUS_SET_OOM(error);
++              return BUS_RESULT_FALSE;
++            }
++
++          bus_deferred_message_unref(deferred_message);
++          return BUS_RESULT_TRUE; /* pretend to have sent it */
++        }
++
++      if (dispatched_deferred_message != NULL)
++        {
++          result = bus_deferred_message_get_response(dispatched_deferred_message);
++          if (result == BUS_RESULT_TRUE)
++            {
++              /* if we know the result of policy check we still need to check if message limits
++               * are not exceeded. It is also required to add entry in expected replies list if
++               * this is a method call
++               */
++              if (!bus_deferred_message_check_message_limits(dispatched_deferred_message, error))
++                return BUS_RESULT_FALSE;
++
++              if (!bus_deferred_message_expect_method_reply(dispatched_deferred_message, transaction, error))
++                return BUS_RESULT_FALSE;
++            }
++          else if (result == BUS_RESULT_FALSE)
++            {
++              bus_deferred_message_create_error(dispatched_deferred_message, "Rejected message", error);
++              return BUS_RESULT_FALSE;
++            }
++        }
++      else
++        result = BUS_RESULT_LATER;
++
++      if (result == BUS_RESULT_LATER)
++        result = bus_context_check_security_policy(context, transaction,
++            sender, addressed_recipient, addressed_recipient, message, error,
++            &deferred_message);
++
++      switch (result)
++        {
++        case BUS_RESULT_TRUE:
++          break;
++        case BUS_RESULT_FALSE:
++          return BUS_RESULT_FALSE;
++        case BUS_RESULT_LATER:
++          {
++            BusDeferredMessageStatus status;
++
++            if (dispatched_deferred_message != NULL)
++              {
++                /* for deferred dispatch prepend message at the recipient */
++                if (!bus_deferred_message_queue_at_recipient(deferred_message, transaction, TRUE, TRUE))
++                  {
++                    BUS_SET_OOM(error);
++                    return BUS_RESULT_FALSE;
++                  }
++                return BUS_RESULT_TRUE; /* pretend to have sent it */
++              }
++
++            status = bus_deferred_message_get_status(deferred_message);
++
++            if (status & BUS_DEFERRED_MESSAGE_CHECK_SEND)
++              {
++                /* send rule result not available - disable dispatching messages from the sender */
++                bus_deferred_message_disable_sender(deferred_message);
++                return BUS_RESULT_LATER;
++              }
++            else if (status & BUS_DEFERRED_MESSAGE_CHECK_RECEIVE)
++              {
++                /* receive rule result not available - queue message at the recipient */
++                if (!bus_deferred_message_queue_at_recipient(deferred_message, transaction, TRUE, FALSE))
++                  {
++                    BUS_SET_OOM(error);
++                    return BUS_RESULT_FALSE;
++                  }
++
++                return BUS_RESULT_TRUE; /* pretend to have sent it */
++              }
++            else
++            {
++                _dbus_verbose("deferred message has no status field set unexpectedly\n");
++                return BUS_RESULT_FALSE;
+             }
++          }
+         }
+ 
+       if (dbus_message_contains_unix_fds (message) &&
+@@ -157,7 +238,8 @@ bus_dispatch_matches (BusTransaction *transaction,
+         }
+ 
+       /* Dispatch the message */
+-      if (!bus_transaction_send (transaction, addressed_recipient, message))
++      if (!bus_transaction_send(transaction, addressed_recipient, message,
++          dispatched_deferred_message != NULL ? TRUE : FALSE))
+         {
+           BUS_SET_OOM (error);
+           return BUS_RESULT_FALSE;
+@@ -386,7 +468,7 @@ bus_dispatch (DBusConnection *connection,
+    * addressed_recipient == NULL), and match it against other connections'
+    * match rules.
+    */
+-  switch (bus_dispatch_matches (transaction, connection, addressed_recipient, message, &error))
++  switch (bus_dispatch_matches (transaction, connection, addressed_recipient, message, NULL, &error))
+     {
+     case BUS_RESULT_TRUE:
+     case BUS_RESULT_FALSE:
+diff --git a/bus/dispatch.h b/bus/dispatch.h
+index afba6a2..f6102e8 100644
+--- a/bus/dispatch.h
++++ b/bus/dispatch.h
+@@ -29,10 +29,11 @@
+ 
+ dbus_bool_t bus_dispatch_add_connection    (DBusConnection *connection);
+ void        bus_dispatch_remove_connection (DBusConnection *connection);
+-BusResult   bus_dispatch_matches           (BusTransaction *transaction,
+-                                            DBusConnection *sender,
+-                                            DBusConnection *recipient,
+-                                            DBusMessage    *message,
+-                                            DBusError      *error);
++BusResult   bus_dispatch_matches           (BusTransaction     *transaction,
++                                            DBusConnection     *sender,
++                                            DBusConnection     *recipient,
++                                            DBusMessage        *message,
++                                            BusDeferredMessage *dispatched_deferred_message,
++                                            DBusError           *error);
+ 
+ #endif /* BUS_DISPATCH_H */
+diff --git a/bus/driver.c b/bus/driver.c
+index a9e670e..914c681 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -129,7 +129,7 @@ bus_driver_send_service_owner_changed (const char     *service_name,
+ 
+   _dbus_assert (dbus_message_has_signature (message, "sss"));
+ 
+-  switch (bus_dispatch_matches (transaction, NULL, NULL, message, error))
++  switch (bus_dispatch_matches (transaction, NULL, NULL, message, NULL, error))
+     {
+     case BUS_RESULT_TRUE:
+       retval = TRUE;
+diff --git a/bus/policy.c b/bus/policy.c
+index 825d754..914b588 100644
+--- a/bus/policy.c
++++ b/bus/policy.c
+@@ -1196,6 +1196,9 @@ bus_client_policy_check_can_send (DBusConnection      *sender,
+ 
+       result = bus_check_privilege(check, message, sender, addressed_recipient, receiver,
+           privilege, BUS_DEFERRED_MESSAGE_CHECK_SEND, deferred_message);
++      if (result == BUS_RESULT_LATER && deferred_message != NULL)
++        bus_deferred_message_set_policy_check_info(*deferred_message, requested_reply,
++            *toggles, privilege);
+     }
+   else
+     privilege = NULL;
+@@ -1430,6 +1433,9 @@ bus_client_policy_check_can_receive (BusClientPolicy     *policy,
+ 
+       result = bus_check_privilege(check, message, sender, addressed_recipient, proposed_recipient,
+                  privilege, BUS_DEFERRED_MESSAGE_CHECK_RECEIVE, deferred_message);
++      if (result == BUS_RESULT_LATER && deferred_message != NULL)
++        bus_deferred_message_set_policy_check_info(*deferred_message, requested_reply,
++                    *toggles, privilege);
+     }
+   else
+       privilege = NULL;
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0009-Add-check-own-.-support.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0009-Add-check-own-.-support.patch
@@ -1,0 +1,1174 @@
+From 3438f6f7b5ef2951bb79a7a22131e5e5d2398238 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Thu, 27 Nov 2014 11:26:21 +0100
+Subject: [PATCH 09/13] Add <check own="..." > support
+
+Policy result unavailability is handled like send rules - dispatching
+messages from the sender is blocked and resumed when result becomes
+available.
+
+Handler of "RequestName" method needs to return BUS_RESULT_LATER when
+policy result is not known therefore its return type is modified.
+Since bus message handlers are put into function pointer array other
+message handler function singatures are also affected.
+
+Change-Id: I4c2cbd4585e41fccd8a30f825a8f0d342ab56755
+---
+ bus/dispatch.c |  14 +++-
+ bus/driver.c   | 229 ++++++++++++++++++++++++++++++---------------------------
+ bus/driver.h   |   2 +-
+ bus/policy.c   |  51 ++++++++++---
+ bus/policy.h   |   6 +-
+ bus/services.c |  44 ++++++-----
+ bus/services.h |   3 +-
+ bus/smack.c    |  12 +--
+ bus/stats.c    |  16 ++--
+ 9 files changed, 221 insertions(+), 156 deletions(-)
+
+diff --git a/bus/dispatch.c b/bus/dispatch.c
+index 143ff3f..4a2dae8 100644
+--- a/bus/dispatch.c
++++ b/bus/dispatch.c
+@@ -408,8 +408,18 @@ bus_dispatch (DBusConnection *connection,
+         }
+ 
+       _dbus_verbose ("Giving message to %s\n", DBUS_SERVICE_DBUS);
+-      if (!bus_driver_handle_message (connection, transaction, message, &error))
+-        goto out;
++      switch (bus_driver_handle_message (connection, transaction, message, &error))
++        {
++        case BUS_RESULT_TRUE:
++          break;
++        case BUS_RESULT_FALSE:
++          goto out;
++        case BUS_RESULT_LATER:
++          bus_transaction_cancel_and_free (transaction);
++          transaction = NULL;
++          result = DBUS_HANDLER_RESULT_LATER;
++          goto out;
++        }
+     }
+   else if (!bus_connection_is_active (connection)) /* clients must talk to bus driver first */
+     {
+diff --git a/bus/driver.c b/bus/driver.c
+index 914c681..2e6d472 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -299,7 +299,7 @@ create_unique_client_name (BusRegistry *registry,
+   return TRUE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_hello (DBusConnection *connection,
+                          BusTransaction *transaction,
+                          DBusMessage    *message,
+@@ -307,7 +307,7 @@ bus_driver_handle_hello (DBusConnection *connection,
+ {
+   DBusString unique_name;
+   BusService *service;
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusRegistry *registry;
+   BusConnections *connections;
+ 
+@@ -318,7 +318,7 @@ bus_driver_handle_hello (DBusConnection *connection,
+       /* We already handled an Hello message for this connection. */
+       dbus_set_error (error, DBUS_ERROR_FAILED,
+                       "Already handled an Hello message");
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   /* Note that when these limits are exceeded we don't disconnect the
+@@ -332,13 +332,13 @@ bus_driver_handle_hello (DBusConnection *connection,
+                                      error))
+     {
+       _DBUS_ASSERT_ERROR_IS_SET (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!_dbus_string_init (&unique_name))
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   retval = FALSE;
+@@ -374,7 +374,7 @@ bus_driver_handle_hello (DBusConnection *connection,
+     goto out_0;
+ 
+   _dbus_assert (bus_connection_is_active (connection));
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out_0:
+   _dbus_string_free (&unique_name);
+@@ -426,7 +426,7 @@ bus_driver_send_welcome_message (DBusConnection *connection,
+     }
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_list_services (DBusConnection *connection,
+                                  BusTransaction *transaction,
+                                  DBusMessage    *message,
+@@ -448,14 +448,14 @@ bus_driver_handle_list_services (DBusConnection *connection,
+   if (reply == NULL)
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!bus_registry_list_services (registry, &services, &len))
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   dbus_message_iter_init_append (reply, &iter);
+@@ -467,7 +467,7 @@ bus_driver_handle_list_services (DBusConnection *connection,
+       dbus_free_string_array (services);
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   {
+@@ -479,7 +479,7 @@ bus_driver_handle_list_services (DBusConnection *connection,
+         dbus_free_string_array (services);
+         dbus_message_unref (reply);
+         BUS_SET_OOM (error);
+-        return FALSE;
++        return BUS_RESULT_FALSE;
+       }
+   }
+ 
+@@ -492,7 +492,7 @@ bus_driver_handle_list_services (DBusConnection *connection,
+           dbus_free_string_array (services);
+           dbus_message_unref (reply);
+           BUS_SET_OOM (error);
+-          return FALSE;
++          return BUS_RESULT_FALSE;
+         }
+       ++i;
+     }
+@@ -503,23 +503,23 @@ bus_driver_handle_list_services (DBusConnection *connection,
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!bus_transaction_send_from_driver (transaction, connection, reply))
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+   else
+     {
+       dbus_message_unref (reply);
+-      return TRUE;
++      return BUS_RESULT_TRUE;
+     }
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+ 					     BusTransaction *transaction,
+ 					     DBusMessage    *message,
+@@ -541,14 +541,14 @@ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+   if (reply == NULL)
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!bus_activation_list_services (activation, &services, &len))
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   dbus_message_iter_init_append (reply, &iter);
+@@ -560,7 +560,7 @@ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+       dbus_free_string_array (services);
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   {
+@@ -572,7 +572,7 @@ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+ 	dbus_free_string_array (services);
+ 	dbus_message_unref (reply);
+ 	BUS_SET_OOM (error);
+-	return FALSE;
++	return BUS_RESULT_FALSE;
+       }
+   }
+ 
+@@ -585,7 +585,7 @@ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+ 	  dbus_free_string_array (services);
+ 	  dbus_message_unref (reply);
+ 	  BUS_SET_OOM (error);
+-	  return FALSE;
++	  return BUS_RESULT_FALSE;
+ 	}
+       ++i;
+     }
+@@ -596,23 +596,23 @@ bus_driver_handle_list_activatable_services (DBusConnection *connection,
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!bus_transaction_send_from_driver (transaction, connection, reply))
+     {
+       dbus_message_unref (reply);
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+   else
+     {
+       dbus_message_unref (reply);
+-      return TRUE;
++      return BUS_RESULT_TRUE;
+     }
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_acquire_service (DBusConnection *connection,
+                                    BusTransaction *transaction,
+                                    DBusMessage    *message,
+@@ -623,7 +623,7 @@ bus_driver_handle_acquire_service (DBusConnection *connection,
+   const char *name;
+   dbus_uint32_t service_reply;
+   dbus_uint32_t flags;
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusRegistry *registry;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+@@ -634,20 +634,28 @@ bus_driver_handle_acquire_service (DBusConnection *connection,
+                               DBUS_TYPE_STRING, &name,
+                               DBUS_TYPE_UINT32, &flags,
+                               DBUS_TYPE_INVALID))
+-    return FALSE;
++    return BUS_RESULT_FALSE;
+ 
+   _dbus_verbose ("Trying to own name %s with flags 0x%x\n", name, flags);
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+   reply = NULL;
+ 
+   _dbus_string_init_const (&service_name, name);
+ 
+-  if (!bus_registry_acquire_service (registry, connection,
+-                                     &service_name, flags,
+-                                     &service_reply, transaction,
+-                                     error))
+-    goto out;
++  switch (bus_registry_acquire_service (registry, connection, message,
++                                       &service_name, flags,
++                                       &service_reply, transaction,
++                                       error))
++    {
++      case BUS_RESULT_TRUE:
++        break;
++      case BUS_RESULT_FALSE:
++        goto out;
++      case BUS_RESULT_LATER:
++        retval = BUS_RESULT_LATER;
++        goto out;
++    }
+ 
+   reply = dbus_message_new_method_return (message);
+   if (reply == NULL)
+@@ -668,7 +676,7 @@ bus_driver_handle_acquire_service (DBusConnection *connection,
+       goto out;
+     }
+ 
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out:
+   if (reply)
+@@ -676,7 +684,7 @@ bus_driver_handle_acquire_service (DBusConnection *connection,
+   return retval;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_release_service (DBusConnection *connection,
+                                    BusTransaction *transaction,
+                                    DBusMessage    *message,
+@@ -686,7 +694,7 @@ bus_driver_handle_release_service (DBusConnection *connection,
+   DBusString service_name;
+   const char *name;
+   dbus_uint32_t service_reply;
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusRegistry *registry;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+@@ -696,11 +704,11 @@ bus_driver_handle_release_service (DBusConnection *connection,
+   if (!dbus_message_get_args (message, error,
+                               DBUS_TYPE_STRING, &name,
+                               DBUS_TYPE_INVALID))
+-    return FALSE;
++    return BUS_RESULT_FALSE;
+ 
+   _dbus_verbose ("Trying to release name %s\n", name);
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+   reply = NULL;
+ 
+   _dbus_string_init_const (&service_name, name);
+@@ -729,7 +737,7 @@ bus_driver_handle_release_service (DBusConnection *connection,
+       goto out;
+     }
+ 
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out:
+   if (reply)
+@@ -737,7 +745,7 @@ bus_driver_handle_release_service (DBusConnection *connection,
+   return retval;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_service_exists (DBusConnection *connection,
+                                   BusTransaction *transaction,
+                                   DBusMessage    *message,
+@@ -748,7 +756,7 @@ bus_driver_handle_service_exists (DBusConnection *connection,
+   BusService *service;
+   dbus_bool_t service_exists;
+   const char *name;
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusRegistry *registry;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+@@ -758,9 +766,9 @@ bus_driver_handle_service_exists (DBusConnection *connection,
+   if (!dbus_message_get_args (message, error,
+                               DBUS_TYPE_STRING, &name,
+                               DBUS_TYPE_INVALID))
+-    return FALSE;
++    return BUS_RESULT_FALSE;
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+ 
+   if (strcmp (name, DBUS_SERVICE_DBUS) == 0)
+     {
+@@ -794,7 +802,7 @@ bus_driver_handle_service_exists (DBusConnection *connection,
+       goto out;
+     }
+ 
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out:
+   if (reply)
+@@ -811,7 +819,7 @@ bus_driver_handle_activate_service (DBusConnection *connection,
+ {
+   dbus_uint32_t flags;
+   const char *name;
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusActivation *activation;
+ 
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+@@ -825,10 +833,10 @@ bus_driver_handle_activate_service (DBusConnection *connection,
+     {
+       _DBUS_ASSERT_ERROR_IS_SET (error);
+       _dbus_verbose ("No memory to get arguments to StartServiceByName\n");
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+ 
+   if (!bus_activation_activate_service (activation, connection, transaction, FALSE,
+                                         message, name, error))
+@@ -838,7 +846,7 @@ bus_driver_handle_activate_service (DBusConnection *connection,
+       goto out;
+     }
+ 
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out:
+   return retval;
+@@ -874,13 +882,13 @@ send_ack_reply (DBusConnection *connection,
+   return TRUE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_update_activation_environment (DBusConnection *connection,
+                                                  BusTransaction *transaction,
+                                                  DBusMessage    *message,
+                                                  DBusError      *error)
+ {
+-  dbus_bool_t retval;
++  BusResult retval;
+   BusActivation *activation;
+   DBusMessageIter iter;
+   DBusMessageIter dict_iter;
+@@ -903,7 +911,7 @@ bus_driver_handle_update_activation_environment (DBusConnection *connection,
+ 
+   dbus_message_iter_recurse (&iter, &dict_iter);
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+ 
+   /* Then loop through the sent dictionary, add the location of
+    * the environment keys and values to lists. The result will
+@@ -990,7 +998,7 @@ bus_driver_handle_update_activation_environment (DBusConnection *connection,
+                        message, error))
+     goto out;
+ 
+-  retval = TRUE;
++  retval = BUS_RESULT_TRUE;
+ 
+  out:
+   _dbus_list_clear (&keys);
+@@ -998,7 +1006,7 @@ bus_driver_handle_update_activation_environment (DBusConnection *connection,
+   return retval;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_add_match (DBusConnection *connection,
+                              BusTransaction *transaction,
+                              DBusMessage    *message,
+@@ -1057,16 +1065,16 @@ bus_driver_handle_add_match (DBusConnection *connection,
+ 
+   bus_match_rule_unref (rule);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  failed:
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (rule)
+     bus_match_rule_unref (rule);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_remove_match (DBusConnection *connection,
+                                 BusTransaction *transaction,
+                                 DBusMessage    *message,
+@@ -1110,16 +1118,16 @@ bus_driver_handle_remove_match (DBusConnection *connection,
+ 
+   bus_match_rule_unref (rule);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  failed:
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (rule)
+     bus_match_rule_unref (rule);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_service_owner (DBusConnection *connection,
+ 				     BusTransaction *transaction,
+ 				     DBusMessage    *message,
+@@ -1189,7 +1197,7 @@ bus_driver_handle_get_service_owner (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1198,10 +1206,10 @@ bus_driver_handle_get_service_owner (DBusConnection *connection,
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_list_queued_owners (DBusConnection *connection,
+ 				      BusTransaction *transaction,
+ 				      DBusMessage    *message,
+@@ -1292,7 +1300,7 @@ bus_driver_handle_list_queued_owners (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1305,10 +1313,10 @@ bus_driver_handle_list_queued_owners (DBusConnection *connection,
+   if (base_names)
+     _dbus_list_clear (&base_names);
+ 
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_connection_unix_user (DBusConnection *connection,
+                                             BusTransaction *transaction,
+                                             DBusMessage    *message,
+@@ -1353,7 +1361,7 @@ bus_driver_handle_get_connection_unix_user (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1362,10 +1370,10 @@ bus_driver_handle_get_connection_unix_user (DBusConnection *connection,
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_connection_unix_process_id (DBusConnection *connection,
+ 						  BusTransaction *transaction,
+ 						  DBusMessage    *message,
+@@ -1410,7 +1418,7 @@ bus_driver_handle_get_connection_unix_process_id (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1419,10 +1427,10 @@ bus_driver_handle_get_connection_unix_process_id (DBusConnection *connection,
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_adt_audit_session_data (DBusConnection *connection,
+ 					      BusTransaction *transaction,
+ 					      DBusMessage    *message,
+@@ -1466,7 +1474,7 @@ bus_driver_handle_get_adt_audit_session_data (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1475,10 +1483,10 @@ bus_driver_handle_get_adt_audit_session_data (DBusConnection *connection,
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_connection_selinux_security_context (DBusConnection *connection,
+ 							   BusTransaction *transaction,
+ 							   DBusMessage    *message,
+@@ -1520,7 +1528,7 @@ bus_driver_handle_get_connection_selinux_security_context (DBusConnection *conne
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1529,10 +1537,10 @@ bus_driver_handle_get_connection_selinux_security_context (DBusConnection *conne
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_connection_credentials (DBusConnection *connection,
+                                               BusTransaction *transaction,
+                                               DBusMessage    *message,
+@@ -1599,7 +1607,7 @@ bus_driver_handle_get_connection_credentials (DBusConnection *connection,
+       goto oom;
+     }
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1613,10 +1621,10 @@ bus_driver_handle_get_connection_credentials (DBusConnection *connection,
+       dbus_message_unref (reply);
+     }
+ 
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_reload_config (DBusConnection *connection,
+ 				 BusTransaction *transaction,
+ 				 DBusMessage    *message,
+@@ -1641,7 +1649,7 @@ bus_driver_handle_reload_config (DBusConnection *connection,
+     goto oom;
+ 
+   dbus_message_unref (reply);
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1650,10 +1658,10 @@ bus_driver_handle_reload_config (DBusConnection *connection,
+   _DBUS_ASSERT_ERROR_IS_SET (error);
+   if (reply)
+     dbus_message_unref (reply);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_get_id (DBusConnection *connection,
+                           BusTransaction *transaction,
+                           DBusMessage    *message,
+@@ -1669,7 +1677,7 @@ bus_driver_handle_get_id (DBusConnection *connection,
+   if (!_dbus_string_init (&uuid))
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   reply = NULL;
+@@ -1695,7 +1703,7 @@ bus_driver_handle_get_id (DBusConnection *connection,
+ 
+   _dbus_string_free (&uuid);
+   dbus_message_unref (reply);
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+@@ -1705,7 +1713,7 @@ bus_driver_handle_get_id (DBusConnection *connection,
+   if (reply)
+     dbus_message_unref (reply);
+   _dbus_string_free (&uuid);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+ typedef struct
+@@ -1713,10 +1721,10 @@ typedef struct
+   const char *name;
+   const char *in_args;
+   const char *out_args;
+-  dbus_bool_t (* handler) (DBusConnection *connection,
+-                           BusTransaction *transaction,
+-                           DBusMessage    *message,
+-                           DBusError      *error);
++  BusResult (* handler) (DBusConnection *connection,
++                         BusTransaction *transaction,
++                         DBusMessage    *message,
++                         DBusError      *error);
+ } MessageHandler;
+ 
+ /* For speed it might be useful to sort this in order of
+@@ -1931,7 +1939,7 @@ bus_driver_generate_introspect_string (DBusString *xml)
+   return TRUE;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_introspect (DBusConnection *connection,
+                               BusTransaction *transaction,
+                               DBusMessage    *message,
+@@ -1951,13 +1959,13 @@ bus_driver_handle_introspect (DBusConnection *connection,
+ 			       DBUS_TYPE_INVALID))
+     {
+       _DBUS_ASSERT_ERROR_IS_SET (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!_dbus_string_init (&xml))
+     {
+       BUS_SET_OOM (error);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   if (!bus_driver_generate_introspect_string (&xml))
+@@ -1980,7 +1988,7 @@ bus_driver_handle_introspect (DBusConnection *connection,
+   dbus_message_unref (reply);
+   _dbus_string_free (&xml);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+  oom:
+   BUS_SET_OOM (error);
+@@ -1990,10 +1998,10 @@ bus_driver_handle_introspect (DBusConnection *connection,
+ 
+   _dbus_string_free (&xml);
+ 
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-dbus_bool_t
++BusResult
+ bus_driver_handle_message (DBusConnection *connection,
+                            BusTransaction *transaction,
+ 			   DBusMessage    *message,
+@@ -2017,7 +2025,7 @@ bus_driver_handle_message (DBusConnection *connection,
+   if (dbus_message_get_type (message) != DBUS_MESSAGE_TYPE_METHOD_CALL)
+     {
+       _dbus_verbose ("Driver got a non-method-call message, ignoring\n");
+-      return TRUE; /* we just ignore this */
++      return BUS_RESULT_TRUE; /* we just ignore this */
+     }
+ 
+   /* may be NULL, which means "any interface will do" */
+@@ -2059,20 +2067,23 @@ bus_driver_handle_message (DBusConnection *connection,
+                               name, dbus_message_get_signature (message),
+                               mh->in_args);
+               _DBUS_ASSERT_ERROR_IS_SET (error);
+-              return FALSE;
++              return BUS_RESULT_FALSE;
+             }
+ 
+-          if ((* mh->handler) (connection, transaction, message, error))
++          switch ((* mh->handler) (connection, transaction, message, error))
+             {
+-              _DBUS_ASSERT_ERROR_IS_CLEAR (error);
+-              _dbus_verbose ("Driver handler succeeded\n");
+-              return TRUE;
+-            }
+-          else
+-            {
+-              _DBUS_ASSERT_ERROR_IS_SET (error);
+-              _dbus_verbose ("Driver handler returned failure\n");
+-              return FALSE;
++              case BUS_RESULT_TRUE:
++                _DBUS_ASSERT_ERROR_IS_CLEAR (error);
++                _dbus_verbose ("Driver handler succeeded\n");
++                return BUS_RESULT_TRUE;
++              case BUS_RESULT_FALSE:
++                _DBUS_ASSERT_ERROR_IS_SET (error);
++                _dbus_verbose ("Driver handler returned failure\n");
++                return BUS_RESULT_FALSE;
++              case BUS_RESULT_LATER:
++                _DBUS_ASSERT_ERROR_IS_CLEAR (error);
++                _dbus_verbose ("Driver handler delayed message processing due to policy check\n");
++                return BUS_RESULT_LATER;
+             }
+         }
+     }
+@@ -2084,7 +2095,7 @@ bus_driver_handle_message (DBusConnection *connection,
+                   "%s does not understand message %s",
+                   DBUS_SERVICE_DBUS, name);
+ 
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+ void
+diff --git a/bus/driver.h b/bus/driver.h
+index 713b276..8829266 100644
+--- a/bus/driver.h
++++ b/bus/driver.h
+@@ -28,7 +28,7 @@
+ #include "connection.h"
+ 
+ void        bus_driver_remove_connection     (DBusConnection *connection);
+-dbus_bool_t bus_driver_handle_message        (DBusConnection *connection,
++BusResult   bus_driver_handle_message        (DBusConnection *connection,
+                                               BusTransaction *transaction,
+                                               DBusMessage    *message,
+                                               DBusError      *error);
+diff --git a/bus/policy.c b/bus/policy.c
+index 914b588..398f7dc 100644
+--- a/bus/policy.c
++++ b/bus/policy.c
+@@ -1448,18 +1448,21 @@ bus_client_policy_check_can_receive (BusClientPolicy     *policy,
+ 
+ 
+ 
+-static dbus_bool_t
++static BusResult
+ bus_rules_check_can_own (DBusList *rules,
+-                         const DBusString *service_name)
++                         const DBusString *service_name,
++                         DBusConnection   *connection,
++                         DBusMessage      *message)
+ {
+   DBusList *link;
+-  dbus_bool_t allowed;
++  BusResult result;
++  const char *privilege;
+   
+   /* rules is in the order the rules appeared
+    * in the config file, i.e. last rule that applies wins
+    */
+ 
+-  allowed = FALSE;
++  result = BUS_RESULT_FALSE;
+   link = _dbus_list_get_first_link (&rules);
+   while (link != NULL)
+     {
+@@ -1495,17 +1498,45 @@ bus_rules_check_can_own (DBusList *rules,
+         }
+ 
+       /* Use this rule */
+-      allowed = rule->access == BUS_POLICY_RULE_ACCESS_ALLOW;
++      switch (rule->access)
++      {
++      case BUS_POLICY_RULE_ACCESS_ALLOW:
++        result = BUS_RESULT_TRUE;
++        break;
++      case BUS_POLICY_RULE_ACCESS_DENY:
++        result = BUS_RESULT_FALSE;
++        break;
++      case BUS_POLICY_RULE_ACCESS_CHECK:
++        result = BUS_RESULT_LATER;
++        privilege = rule->privilege;
++        break;
++      }
+     }
+ 
+-  return allowed;
++  if (result == BUS_RESULT_LATER)
++    {
++      BusContext *context = bus_connection_get_context(connection);
++      BusCheck *check = bus_context_get_check(context);
++      BusDeferredMessage *deferred_message;
++
++      result = bus_check_privilege(check, message, connection, NULL, NULL,
++          privilege, BUS_DEFERRED_MESSAGE_CHECK_OWN, &deferred_message);
++      if (result == BUS_RESULT_LATER)
++        {
++          bus_deferred_message_disable_sender(deferred_message);
++        }
++    }
++
++  return result;
+ }
+ 
+-dbus_bool_t
++BusResult
+ bus_client_policy_check_can_own (BusClientPolicy  *policy,
+-                                 const DBusString *service_name)
++                                 const DBusString *service_name,
++                                 DBusConnection   *connection,
++                                 DBusMessage      *message)
+ {
+-  return bus_rules_check_can_own (policy->rules, service_name);
++  return bus_rules_check_can_own (policy->rules, service_name, connection, message);
+ }
+ 
+ #ifdef DBUS_ENABLE_EMBEDDED_TESTS
+@@ -1513,7 +1544,7 @@ dbus_bool_t
+ bus_policy_check_can_own (BusPolicy  *policy,
+                           const DBusString *service_name)
+ {
+-  return bus_rules_check_can_own (policy->default_rules, service_name);
++  return bus_rules_check_can_own (policy->default_rules, service_name, NULL, NULL);
+ }
+ #endif /* DBUS_ENABLE_EMBEDDED_TESTS */
+ 
+diff --git a/bus/policy.h b/bus/policy.h
+index 08979d2..0a3258e 100644
+--- a/bus/policy.h
++++ b/bus/policy.h
+@@ -173,8 +173,10 @@ BusResult        bus_client_policy_check_can_receive (BusClientPolicy     *polic
+                                                       dbus_int32_t        *toggles,
+                                                       const char         **privilege_param,
+                                                       BusDeferredMessage **deferred_message);
+-dbus_bool_t      bus_client_policy_check_can_own     (BusClientPolicy  *policy,
+-                                                      const DBusString *service_name);
++BusResult        bus_client_policy_check_can_own     (BusClientPolicy  *policy,
++                                                      const DBusString *service_name,
++                                                      DBusConnection   *connection,
++                                                      DBusMessage      *message);
+ dbus_bool_t      bus_client_policy_append_rule       (BusClientPolicy  *policy,
+                                                       BusPolicyRule    *rule);
+ void             bus_client_policy_optimize          (BusClientPolicy  *policy);
+diff --git a/bus/services.c b/bus/services.c
+index 584485b..d15ae9f 100644
+--- a/bus/services.c
++++ b/bus/services.c
+@@ -374,16 +374,17 @@ bus_registry_list_services (BusRegistry *registry,
+   return FALSE;
+ }
+ 
+-dbus_bool_t
++BusResult
+ bus_registry_acquire_service (BusRegistry      *registry,
+                               DBusConnection   *connection,
++                              DBusMessage      *message,
+                               const DBusString *service_name,
+                               dbus_uint32_t     flags,
+                               dbus_uint32_t    *result,
+                               BusTransaction   *transaction,
+                               DBusError        *error)
+ {
+-  dbus_bool_t retval;
++  BusResult retval;
+   DBusConnection *old_owner_conn;
+   BusClientPolicy *policy;
+   BusService *service;
+@@ -391,7 +392,7 @@ bus_registry_acquire_service (BusRegistry      *registry,
+   BusSELinuxID *sid;
+   BusOwner *primary_owner;
+  
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+ 
+   if (!_dbus_validate_bus_name (service_name, 0,
+                                 _dbus_string_get_length (service_name)))
+@@ -459,16 +460,22 @@ bus_registry_acquire_service (BusRegistry      *registry,
+       goto out;
+     }
+   
+-  if (!bus_client_policy_check_can_own (policy, service_name))
++  switch (bus_client_policy_check_can_own (policy, service_name, connection, message))
+     {
+-      dbus_set_error (error, DBUS_ERROR_ACCESS_DENIED,
+-                      "Connection \"%s\" is not allowed to own the service \"%s\" due "
+-                      "to security policies in the configuration file",
+-                      bus_connection_is_active (connection) ?
+-                      bus_connection_get_name (connection) :
+-                      "(inactive)",
+-                      _dbus_string_get_const_data (service_name));
+-      goto out;
++      case BUS_RESULT_TRUE:
++        break;
++      case BUS_RESULT_FALSE:
++        dbus_set_error (error, DBUS_ERROR_ACCESS_DENIED,
++                              "Connection \"%s\" is not allowed to own the service \"%s\" due "
++                              "to security policies in the configuration file",
++                              bus_connection_is_active (connection) ?
++                              bus_connection_get_name (connection) :
++                              "(inactive)",
++                              _dbus_string_get_const_data (service_name));
++        goto out;
++      case BUS_RESULT_LATER:
++        retval = BUS_RESULT_LATER;
++        goto out;
+     }
+ 
+   if (bus_connection_get_n_services_owned (connection) >=
+@@ -586,12 +593,15 @@ bus_registry_acquire_service (BusRegistry      *registry,
+     }
+ 
+   activation = bus_context_get_activation (registry->context);
+-  retval = bus_activation_send_pending_auto_activation_messages (activation,
+-								 service,
+-								 transaction);
+-  if (!retval)
++  if (bus_activation_send_pending_auto_activation_messages (activation,
++                                                            service,
++                                                            transaction)) {
++    retval = BUS_RESULT_TRUE;
++  } else {
+     BUS_SET_OOM (error);
+-  
++    retval = BUS_RESULT_FALSE;
++  }
++
+  out:
+   return retval;
+ }
+diff --git a/bus/services.h b/bus/services.h
+index 056dd9f..3df3dd7 100644
+--- a/bus/services.h
++++ b/bus/services.h
+@@ -50,8 +50,9 @@ void         bus_registry_foreach         (BusRegistry                 *registry
+ dbus_bool_t  bus_registry_list_services   (BusRegistry                 *registry,
+                                            char                      ***listp,
+                                            int                         *array_len);
+-dbus_bool_t  bus_registry_acquire_service (BusRegistry                 *registry,
++BusResult    bus_registry_acquire_service (BusRegistry                 *registry,
+                                            DBusConnection              *connection,
++                                           DBusMessage                 *message,
+                                            const DBusString            *service_name,
+                                            dbus_uint32_t                flags,
+                                            dbus_uint32_t               *result,
+diff --git a/bus/smack.c b/bus/smack.c
+index 300d9da..eb67ee6 100644
+--- a/bus/smack.c
++++ b/bus/smack.c
+@@ -40,7 +40,7 @@
+ #define SMACK_READ_WRITE "RW"
+ 
+ 
+-dbus_bool_t
++BusResult
+ bus_smack_handle_get_connection_context (DBusConnection *connection,
+                                          BusTransaction *transaction,
+                                          DBusMessage    *message,
+@@ -61,7 +61,7 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+ 
+   if (!dbus_message_get_args (message, error, DBUS_TYPE_STRING, &remote_end,
+                               DBUS_TYPE_INVALID))
+-    return FALSE;
++    return BUS_RESULT_FALSE;
+ 
+   _dbus_verbose ("asked for label of connection %s\n", remote_end);
+ 
+@@ -72,7 +72,7 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+     {
+       dbus_set_error (error, DBUS_ERROR_NAME_HAS_NO_OWNER,
+                       "Bus name '%s' has no owner", remote_end);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   remote_connection = bus_service_get_primary_owners_connection (service);
+@@ -100,7 +100,7 @@ bus_smack_handle_get_connection_context (DBusConnection *connection,
+ 
+   dbus_message_unref (reply);
+ 
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+ oom:
+   BUS_SET_OOM (error);
+@@ -109,11 +109,11 @@ err:
+   if (reply != NULL)
+     dbus_message_unref (reply);
+ 
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ #else
+   dbus_set_error (error, DBUS_ERROR_NOT_SUPPORTED,
+                   "SMACK support is not enabled");
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ #endif
+ }
+ 
+diff --git a/bus/stats.c b/bus/stats.c
+index 24308eb..569163a 100644
+--- a/bus/stats.c
++++ b/bus/stats.c
+@@ -34,7 +34,7 @@
+ 
+ #ifdef DBUS_ENABLE_STATS
+ 
+-dbus_bool_t
++BusResult
+ bus_stats_handle_get_stats (DBusConnection *connection,
+                             BusTransaction *transaction,
+                             DBusMessage    *message,
+@@ -102,17 +102,17 @@ bus_stats_handle_get_stats (DBusConnection *connection,
+     goto oom;
+ 
+   dbus_message_unref (reply);
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+ oom:
+   if (reply != NULL)
+     dbus_message_unref (reply);
+ 
+   BUS_SET_OOM (error);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+-dbus_bool_t
++BusResult
+ bus_stats_handle_get_connection_stats (DBusConnection *caller_connection,
+                                        BusTransaction *transaction,
+                                        DBusMessage    *message,
+@@ -136,7 +136,7 @@ bus_stats_handle_get_connection_stats (DBusConnection *caller_connection,
+   if (! dbus_message_get_args (message, error,
+                                DBUS_TYPE_STRING, &bus_name,
+                                DBUS_TYPE_INVALID))
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+ 
+   _dbus_string_init_const (&bus_name_str, bus_name);
+   service = bus_registry_lookup (registry, &bus_name_str);
+@@ -145,7 +145,7 @@ bus_stats_handle_get_connection_stats (DBusConnection *caller_connection,
+     {
+       dbus_set_error (error, DBUS_ERROR_NAME_HAS_NO_OWNER,
+                       "Bus name '%s' has no owner", bus_name);
+-      return FALSE;
++      return BUS_RESULT_FALSE;
+     }
+ 
+   stats_connection = bus_service_get_primary_owners_connection (service);
+@@ -207,14 +207,14 @@ bus_stats_handle_get_connection_stats (DBusConnection *caller_connection,
+     goto oom;
+ 
+   dbus_message_unref (reply);
+-  return TRUE;
++  return BUS_RESULT_TRUE;
+ 
+ oom:
+   if (reply != NULL)
+     dbus_message_unref (reply);
+ 
+   BUS_SET_OOM (error);
+-  return FALSE;
++  return BUS_RESULT_FALSE;
+ }
+ 
+ #endif
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0010-Fix-several-BusResult-dbus_bool_t-mismatches.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0010-Fix-several-BusResult-dbus_bool_t-mismatches.patch
@@ -1,0 +1,66 @@
+From 3fc110572dc9953b8f8809373224c741cdb71223 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Mon, 9 Feb 2015 16:25:31 +0100
+Subject: [PATCH 10/13] Fix several BusResult/dbus_bool_t mismatches
+
+They were found by temporarily redefining BusResult in the following way:
+
+ typedef enum { BUS_RESULT_TRUE_E, BUS_RESULT_FALSE_E, BUS_RESULT_LATER_E } bus_result_t;
+ typedef struct { bus_result_t result; } BusResult;
+ #define BUS_RESULT_TRUE ((BusResult){BUS_RESULT_TRUE_E})
+ #define BUS_RESULT_FALSE ((BusResult){BUS_RESULT_FALSE_E})
+ #define BUS_RESULT_LATER ((BusResult){BUS_RESULT_LATER_E})
+
+It doesn't compile because equality operator is not defined for structs.
+Also, structs are not allowed in switch statement. However, some errors
+indicated type mismatches which are now fixed.
+
+Change-Id: I0eb5368359f342e0f4239a2ad95d34b9a8e10a23
+Signed-off-by: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+---
+ bus/driver.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/bus/driver.c b/bus/driver.c
+index 2e6d472..9eb0ae2 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -341,7 +341,7 @@ bus_driver_handle_hello (DBusConnection *connection,
+       return BUS_RESULT_FALSE;
+     }
+ 
+-  retval = FALSE;
++  retval = BUS_RESULT_FALSE;
+ 
+   registry = bus_connection_get_registry (connection);
+ 
+@@ -811,7 +811,7 @@ bus_driver_handle_service_exists (DBusConnection *connection,
+   return retval;
+ }
+ 
+-static dbus_bool_t
++static BusResult
+ bus_driver_handle_activate_service (DBusConnection *connection,
+                                     BusTransaction *transaction,
+                                     DBusMessage    *message,
+@@ -1813,7 +1813,7 @@ static const MessageHandler dbus_message_handlers[] = {
+   { NULL, NULL, NULL, NULL }
+ };
+ 
+-static dbus_bool_t bus_driver_handle_introspect (DBusConnection *,
++static BusResult bus_driver_handle_introspect (DBusConnection *,
+     BusTransaction *, DBusMessage *, DBusError *);
+ 
+ static const MessageHandler introspectable_message_handlers[] = {
+@@ -2019,7 +2019,7 @@ bus_driver_handle_message (DBusConnection *connection,
+       BusContext *context;
+ 
+       context = bus_connection_get_context (connection);
+-      return dbus_activation_systemd_failure(bus_context_get_activation(context), message);
++      return dbus_activation_systemd_failure(bus_context_get_activation(context), message) == TRUE ? BUS_RESULT_TRUE : BUS_RESULT_FALSE;
+     }
+ 
+   if (dbus_message_get_type (message) != DBUS_MESSAGE_TYPE_METHOD_CALL)
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0011-Do-not-rely-on-Cynara-cache-when-processing-check-ru.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0011-Do-not-rely-on-Cynara-cache-when-processing-check-ru.patch
@@ -1,0 +1,191 @@
+From 09e4161203d38bd0f7745791d536d86cac4a7740 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Tue, 3 Mar 2015 17:37:39 +0100
+Subject: [PATCH 11/13] Do not rely on Cynara cache when processing check rules
+
+Cynara cache was required when processing messages that have been
+blocked at the sender's message queue. Reliance on cache turned out to be
+unacceptable due to the fact that some policies are not cacheable. For example
+responses provided by Cynara askuser plugin might be single-use and thus cannot
+be cached.
+
+The solution is to attach deferred message to the message object when policy result
+is unavailable. Upon next bus_check_privilege call use response from Cynara which
+is saved in deferred message object.
+
+Change-Id: I17152343540d7b8d13ad3540c25c043d57aa5949
+---
+ bus/check.c  | 75 +++++++++++++++++++++++++++++++++++++++++++++++++++++-------
+ bus/cynara.c |  7 +++++-
+ 2 files changed, 73 insertions(+), 9 deletions(-)
+
+diff --git a/bus/check.c b/bus/check.c
+index baff981..0d5994e 100644
+--- a/bus/check.c
++++ b/bus/check.c
+@@ -58,6 +58,8 @@ typedef struct BusDeferredMessage
+   BusCheckResponseFunc response_callback;
+ } BusDeferredMessage;
+ 
++static dbus_int32_t deferred_message_data_slot = -1;
++
+ BusCheck *
+ bus_check_new (BusContext *context, DBusError *error)
+ {
+@@ -70,11 +72,19 @@ bus_check_new (BusContext *context, DBusError *error)
+       return NULL;
+     }
+ 
++  if (!dbus_message_allocate_data_slot(&deferred_message_data_slot))
++    {
++      dbus_free(check);
++      BUS_SET_OOM(error);
++      return NULL;
++    }
++
+   check->refcount = 1;
+   check->context = context;
+   check->cynara = bus_cynara_new(check, error);
+   if (dbus_error_is_set(error))
+     {
++      dbus_message_free_data_slot(&deferred_message_data_slot);
+       dbus_free(check);
+       return NULL;
+     }
+@@ -101,6 +111,7 @@ bus_check_unref (BusCheck *check)
+   if (check->refcount == 0)
+     {
+       bus_cynara_unref(check->cynara);
++      dbus_message_free_data_slot(&deferred_message_data_slot);
+       dbus_free(check);
+     }
+ }
+@@ -122,6 +133,8 @@ bus_check_enable_dispatch_callback (BusDeferredMessage *deferred_message,
+                                     BusResult result)
+ {
+   _dbus_verbose("bus_check_enable_dispatch_callback called deferred_message=%p\n", deferred_message);
++
++  deferred_message->response = result;
+   _dbus_connection_enable_dispatch(deferred_message->sender);
+ }
+ 
+@@ -208,12 +221,26 @@ bus_deferred_message_queue_at_recipient (BusDeferredMessage *deferred_message,
+   return TRUE;
+ }
+ 
++static void
++deferred_message_free_function(void *data)
++{
++  BusDeferredMessage *deferred_message = (BusDeferredMessage *)data;
++  bus_deferred_message_unref(deferred_message);
++}
++
+ void
+ bus_deferred_message_disable_sender (BusDeferredMessage *deferred_message)
+ {
+   _dbus_assert(deferred_message != NULL);
+   _dbus_assert(deferred_message->sender != NULL);
+ 
++  if (dbus_message_get_data(deferred_message->message, deferred_message_data_slot) == NULL)
++    {
++      if (dbus_message_set_data(deferred_message->message, deferred_message_data_slot, deferred_message,
++          deferred_message_free_function))
++        bus_deferred_message_ref(deferred_message);
++    }
++
+   _dbus_connection_disable_dispatch(deferred_message->sender);
+   deferred_message->response_callback = bus_check_enable_dispatch_callback;
+ }
+@@ -247,6 +274,7 @@ bus_check_privilege (BusCheck *check,
+                      BusDeferredMessageStatus check_type,
+                      BusDeferredMessage **deferred_message)
+ {
++  BusDeferredMessage *previous_deferred_message;
+   BusResult result = BUS_RESULT_FALSE;
+   BusCynara *cynara;
+   DBusConnection *connection;
+@@ -263,16 +291,47 @@ bus_check_privilege (BusCheck *check,
+     return bus_check_test_override (connection, privilege);
+ #endif
+ 
+-  /* ask policy checkers */
++  previous_deferred_message = dbus_message_get_data(message, deferred_message_data_slot);
++  /* check if message blocked at sender's queue is being processed */
++  if (previous_deferred_message != NULL)
++    {
++      if ((check_type & BUS_DEFERRED_MESSAGE_CHECK_SEND) &&
++          !(previous_deferred_message->status & BUS_DEFERRED_MESSAGE_CHECK_SEND))
++        {
++          /**
++           * Message has been deferred due to receive or own rule which means that sending this message
++           * is allowed - it must have been checked previously.
++           */
++          result = BUS_RESULT_TRUE;
++        }
++      else
++        {
++          result = previous_deferred_message->response;
++          if (result == BUS_RESULT_LATER)
++            {
++              /* result is still not known - reuse deferred message object */
++              if (deferred_message != NULL)
++                *deferred_message = previous_deferred_message;
++            }
++          else
++            {
++              /* result is available - we can remove deferred message from the processed message */
++              dbus_message_set_data(message, deferred_message_data_slot, NULL, NULL);
++            }
++        }
++    }
++  else
++    {
++      /* ask policy checkers */
+ #ifdef DBUS_ENABLE_CYNARA
+-  cynara = bus_check_get_cynara(check);
+-  result = bus_cynara_check_privilege(cynara, message, sender, addressed_recipient,
+-      proposed_recipient, privilege, check_type, deferred_message);
++      cynara = bus_check_get_cynara(check);
++      result = bus_cynara_check_privilege(cynara, message, sender, addressed_recipient,
++          proposed_recipient, privilege, check_type, deferred_message);
+ #endif
+-
+-  if (result == BUS_RESULT_LATER && deferred_message != NULL)
+-    {
+-      (*deferred_message)->status |= check_type;
++      if (result == BUS_RESULT_LATER && deferred_message != NULL)
++        {
++          (*deferred_message)->status |= check_type;
++        }
+     }
+   return result;
+ }
+diff --git a/bus/cynara.c b/bus/cynara.c
+index d659574..e61c3a2 100644
+--- a/bus/cynara.c
++++ b/bus/cynara.c
+@@ -35,6 +35,7 @@
+ #include <cynara-client-async.h>
+ #endif
+ 
++#define USE_CYNARA_CACHE 1
+ 
+ #ifdef DBUS_ENABLE_CYNARA
+ typedef struct BusCynara
+@@ -166,8 +167,12 @@ bus_cynara_check_privilege (BusCynara *cynara,
+ 
+   snprintf(user, sizeof(user), "%lu", uid);
+ 
+-
++#if USE_CYNARA_CACHE
+   result = cynara_async_check_cache(cynara->cynara, label, session_id, user, privilege);
++#else
++  result = CYNARA_API_CACHE_MISS;
++#endif
++
+   switch (result)
+   {
+   case CYNARA_API_ACCESS_ALLOWED:
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0012-Perform-Cynara-runtime-policy-checks-by-default.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0012-Perform-Cynara-runtime-policy-checks-by-default.patch
@@ -1,0 +1,122 @@
+From 9cd5f5e09e3e19e80d9527259a94fecd9b20cb66 Mon Sep 17 00:00:00 2001
+From: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+Date: Wed, 3 Dec 2014 16:33:40 +0100
+Subject: [PATCH 12/13] Perform Cynara runtime policy checks by default
+
+By default clients are checked for http://tizen.org/privilege/internal/dbus
+privilege for method calls, sending and receiving signals.
+Services are supposed to override these defaults if certain resources
+are going to be exposed to applications.
+Method replies and errors are allowed by default.
+
+Note that previously every message sent via session bus was allowed by
+default. This has changed and session policy is now basically the same as
+system configuration with 2 exceptions:
+ - session bus only allows connections from the same user the session bus
+   is running while system bus permits all users
+ - requesting names is denied by default for system bus while session bus
+   requires http://tizen.org/privilege/internal/dbus privilege
+
+Change-Id: Ifb4a160bf6e0638404e0295a2e4fa3077efd881c
+Signed-off-by: Jacek Bukarewicz <j.bukarewicz@samsung.com>
+---
+ bus/session.conf.in | 32 ++++++++++++++++++++++++++------
+ bus/system.conf.in  | 29 ++++++++++++++++++++---------
+ 2 files changed, 46 insertions(+), 15 deletions(-)
+
+diff --git a/bus/session.conf.in b/bus/session.conf.in
+index cfe9544..7963c70 100644
+--- a/bus/session.conf.in
++++ b/bus/session.conf.in
+@@ -17,12 +17,32 @@
+   <standard_session_servicedirs />
+ 
+   <policy context="default">
+-    <!-- Allow everything to be sent -->
+-    <allow send_destination="*" eavesdrop="true"/>
+-    <!-- Allow everything to be received -->
+-    <allow eavesdrop="true"/>
+-    <!-- Allow anyone to own anything -->
+-    <allow own="*"/>
++    <!-- By default clients require internal/dbus privilege to communicate
++         with D-Bus services and to claim name ownership. This is internal privilege that
++         is only accessible to trusted system services -->
++    <check own="*"                  privilege="http://tizen.org/privilege/internal/dbus" />
++    <check send_type="method_call"  privilege="http://tizen.org/privilege/internal/dbus" />
++    <check send_type="signal"       privilege="http://tizen.org/privilege/internal/dbus" />
++    <check receive_type="signal"    privilege="http://tizen.org/privilege/internal/dbus" />
++
++    <!-- Reply messages (method returns, errors) are allowed
++         by default -->
++    <allow send_requested_reply="true" send_type="method_return"/>
++    <allow send_requested_reply="true" send_type="error"/>
++
++    <!-- All messages but signals may be received by default -->
++    <allow receive_type="method_call"/>
++    <allow receive_type="method_return"/>
++    <allow receive_type="error"/>
++
++    <!-- Allow anyone to talk to the message bus -->
++    <allow send_destination="org.freedesktop.DBus"/>
++    <allow receive_sender="org.freedesktop.DBus"/>
++
++    <!-- But disallow some specific bus services -->
++    <deny send_destination="org.freedesktop.DBus"
++          send_interface="org.freedesktop.DBus"
++          send_member="UpdateActivationEnvironment"/>
+   </policy>
+ 
+   <!-- Config files are placed here that among other things, 
+diff --git a/bus/system.conf.in b/bus/system.conf.in
+index 92f4cc4..f3fd974 100644
+--- a/bus/system.conf.in
++++ b/bus/system.conf.in
+@@ -46,25 +46,36 @@
+     <allow user="*"/>
+ 
+     <!-- Holes must be punched in service configuration files for
+-         name ownership and sending method calls -->
+-    <deny own="*"/>
+-    <deny send_type="method_call"/>
++         name ownership -->
++    <deny own="*" />
+ 
+-    <!-- Signals and reply messages (method returns, errors) are allowed
++    <!-- By default clients require internal/dbus privilege to communicate
++         with D-Bus services. This is internal privilege that is only accessible
++         to trusted system services -->
++    <check send_type="method_call"  privilege="http://tizen.org/privilege/internal/dbus" />
++    <check send_type="signal"       privilege="http://tizen.org/privilege/internal/dbus" />
++    <check receive_type="signal"    privilege="http://tizen.org/privilege/internal/dbus" />
++
++    <!-- Reply messages (method returns, errors) are allowed
+          by default -->
+-    <allow send_type="signal"/>
+     <allow send_requested_reply="true" send_type="method_return"/>
+     <allow send_requested_reply="true" send_type="error"/>
+ 
+-    <!-- All messages may be received by default -->
++    <!-- All messages but signals may be received by default -->
+     <allow receive_type="method_call"/>
+     <allow receive_type="method_return"/>
+     <allow receive_type="error"/>
+-    <allow receive_type="signal"/>
+ 
+-    <!-- Allow anyone to talk to the message bus -->
++    <!-- If there is a need specific bus services could be protected by Cynara as well.
++         However, this can lead to deadlock during the boot process when such check is made and
++         Cynara is not yet activated (systemd calls protected method synchronously,
++         dbus daemon tries to consult Cynara, Cynara waits for systemd activation).
++         Therefore it is advised to allow root processes to use bus services.
++         Currently anyone is allowed to talk to the message bus -->
+     <allow send_destination="org.freedesktop.DBus"/>
+-    <!-- But disallow some specific bus services -->
++    <allow receive_sender="org.freedesktop.DBus"/>
++
++    <!-- Disallow some specific bus services -->
+     <deny send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus"
+           send_member="UpdateActivationEnvironment"/>
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus/0013-various-compile-fixes.patch
+++ b/meta-security-framework/recipes-core/dbus/dbus/0013-various-compile-fixes.patch
@@ -1,0 +1,69 @@
+From 22cbd5ebaf3fbb86ff1ff8a0cc934d2181453e1b Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Tue, 2 Jun 2015 14:58:48 +0200
+Subject: [PATCH 13/13] various compile fixes
+
+Some of these should be squashed into the commits introducing the offending code.
+For now keep them separate, because the entire rebasing should be redone in a cleaner
+way (see https://bugs.tizen.org/jira/browse/TC-2520).
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ bus/activation.c | 5 ++++-
+ bus/check.c      | 2 ++
+ bus/driver.c     | 1 +
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/bus/activation.c b/bus/activation.c
+index be2bc40..73990fc 100644
+--- a/bus/activation.c
++++ b/bus/activation.c
+@@ -1240,8 +1240,10 @@ bus_activation_send_pending_auto_activation_messages (BusActivation  *activation
+                     if (putback_message->connection == entry->connection)
+                       {
+                         if (!_dbus_connection_putback_message (putback_message->connection, last_inserted_message,
+-                              putback_message->activation_message, error))
++                              putback_message->activation_message, &error)) {
++                          /* Can only fail due to OOM, in which case error was set to the OOM error. Ignore that... */
+                           goto error;
++                        }
+                         last_inserted_message = putback_message->activation_message;
+                         putback_message->is_put_back = TRUE;
+                       }
+@@ -2076,6 +2078,7 @@ bus_activation_activate_service (BusActivation  *activation,
+                   retval = TRUE;
+                   break;
+                 case BUS_RESULT_FALSE:
++                default: // needed to silence "‘retval’ may be used uninitialized in this function" warnings
+                   retval = FALSE;
+                   break;
+                 case BUS_RESULT_LATER:
+diff --git a/bus/check.c b/bus/check.c
+index 0d5994e..c464276 100644
+--- a/bus/check.c
++++ b/bus/check.c
+@@ -276,7 +276,9 @@ bus_check_privilege (BusCheck *check,
+ {
+   BusDeferredMessage *previous_deferred_message;
+   BusResult result = BUS_RESULT_FALSE;
++#ifdef DBUS_ENABLE_CYNARA
+   BusCynara *cynara;
++#endif
+   DBusConnection *connection;
+ 
+   connection = check_type == BUS_DEFERRED_MESSAGE_CHECK_RECEIVE ? proposed_recipient : sender;
+diff --git a/bus/driver.c b/bus/driver.c
+index 9eb0ae2..f6314b9 100644
+--- a/bus/driver.c
++++ b/bus/driver.c
+@@ -135,6 +135,7 @@ bus_driver_send_service_owner_changed (const char     *service_name,
+       retval = TRUE;
+       break;
+     case BUS_RESULT_FALSE:
++    default: /* needed to silence "‘retval’ may be used uninitialized in this function" warning */
+       retval = FALSE;
+       break;
+     case BUS_RESULT_LATER:
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-core/dbus/dbus_1.8.10.bbappend
+++ b/meta-security-framework/recipes-core/dbus/dbus_1.8.10.bbappend
@@ -1,0 +1,27 @@
+# Optionally, compilation of the main package with the daemon gets moved into
+# dbus-cynara. That is necessary to break a dependency cycle once the
+# daemon gets compiled with Cynara support (dbus -> cynara -> systemd
+# -> dbus).
+do_install_append_class-target () {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'dbus-cynara', 'true', 'false', d)}; then
+        for i in ${@' '.join([d.getVar('D', True) + x for x in (d.getVar('FILES_dbus', True) or '').split()])}; do
+            rm -rf $i
+        done
+
+        # Try to remove empty directories, starting with the
+        # longest path (= deepest directory) first.
+        # Find needs a valid current directory. Somehow the directory
+        # we get called in is gone by the time that we get invoked.
+        ( cd ${D}
+          for i in `find . -type d | sort -r`; do
+            rmdir $i || true
+          done
+        )
+    fi
+}
+
+# The main package will be empty, but we want to have it created
+# anyway because of the dependencies on it. Installing it will pull in
+# the replacement dbus-cynara package.
+ALLOW_EMPTY_${PN}_class-target = "1"
+RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('DISTRO_FEATURES', 'dbus-cynara', ' dbus-cynara', '', d)}"

--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -48,8 +48,7 @@ do_install_append () {
 
 RDEPENDS_${PN} += "smack"
 pkg_postinst_${PN} () {
-#!/bin/sh -e
-
+   set -e
    chsmack -a System $D${TZ_SYS_DB}/.security-manager.db
    chsmack -a System $D${TZ_SYS_DB}/.security-manager.db-journal
 }

--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -57,3 +57,17 @@ FILES_${PN} += " \
 ${systemd_unitdir} \
 ${TZ_SYS_DB} \
 "
+
+PACKAGES =+ "${PN}-policy"
+FILES_${PN}-policy = " \
+   ${datadir}/${PN} \
+   ${bindir}/security-manager-policy-reload \
+"
+RDEPENDS_${PN}-policy += "sqlite3 cynara"
+pkg_postinst_${PN}-policy () {
+   if [ x"$D" != "x" ] && ${bindir}/security-manager-policy-reload; then
+       exit 0
+   else
+       exit 1
+   fi
+}

--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -32,7 +32,7 @@ EXTRA_OECMAKE = " \
 -DBIN_INSTALL_DIR=${bindir} \
 -DDB_INSTALL_DIR=${TZ_SYS_DB} \
 -DLIB_INSTALL_DIR=${libdir} \
--DSHARE_INSTALL_PREFIX=${localstatedir} \
+-DSHARE_INSTALL_PREFIX=${datadir} \
 -DINCLUDE_INSTALL_DIR=${includedir} \
 "
 

--- a/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
+++ b/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
@@ -1,8 +1,8 @@
 require security-manager.inc
 
-PV = "1.0.1+git${SRCPV}"
-SRCREV = "6eb825a3876061b2e152d42974e117dcbedf7c70"
-SRC_URI += "git://review.tizen.org/platform/core/security/security-manager;nobranch=1"
+PV = "1.0.2+git${SRCPV}"
+SRCREV = "860305a595d681d650024ad07b3b0977e1fcb0a6"
+SRC_URI += "git://github.com/Samsung/security-manager.git"
 S = "${WORKDIR}/git"
 
 SRC_URI += "file://systemd-stop-using-compat-libs.patch"


### PR DESCRIPTION
This updates SecurityManager to 1.0.2 from Github, enables loading of the default policy (via the new security-manager-policy package's postinst), and optionally patches D-Bus to use Cynara.
