### PR TITLE
Fix some compile errors

### DIFF
--- a/meta-integrity/recipes-security/ima-evm-utils/ima-evm-utils/evmctl.c-do-not-depend-on-xattr.h-with-IMA-defines.patch
+++ b/meta-integrity/recipes-security/ima-evm-utils/ima-evm-utils/evmctl.c-do-not-depend-on-xattr.h-with-IMA-defines.patch
@@ -1,0 +1,46 @@
+From 0004b7a2f4717c370c3263e5c649ec7b526d533f Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Wed, 17 Jun 2015 14:28:18 +0200
+Subject: [PATCH] evmctl.c: do not depend on xattr.h with IMA defines
+
+Compilation on older Linux distros (like Ubuntu 12.04) fails
+because linux/xattr.h does not yet have the IMA defines. Compiling
+there makes sense when only the tools are needed, for example when
+signing an image in cross-compile mode.
+
+To support this, add fallbacks for the two defines which are needed.
+Their value is part of the Linux ABI and thus fixed.
+
+Upstream-status: Submitted [linux-ima-devel@lists.sourceforge.net]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ src/evmctl.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/evmctl.c b/src/evmctl.c
+index 109b82a..3dfd432 100644
+--- a/src/evmctl.c
++++ b/src/evmctl.c
+@@ -55,6 +55,18 @@
+ #include <keyutils.h>
+ #include <ctype.h>
+ 
++/*
++ * linux/xattr.h might be old to have this. Allow compilation on older
++ * Linux distros (like Ubuntu 12.04) by falling back to our own
++ * definition.
++ */
++#ifndef XATTR_IMA_SUFFIX
++# define XATTR_IMA_SUFFIX "ima"
++#endif
++#ifndef XATTR_NAME_IMA
++# define XATTR_NAME_IMA XATTR_SECURITY_PREFIX XATTR_IMA_SUFFIX
++#endif
++
+ #include <openssl/sha.h>
+ #include <openssl/pem.h>
+ #include <openssl/hmac.h>
+-- 
+2.1.4
+

--- a/meta-integrity/recipes-security/ima-evm-utils/ima-evm-utils_git.bb
+++ b/meta-integrity/recipes-security/ima-evm-utils/ima-evm-utils_git.bb
@@ -9,3 +9,7 @@ S = "${WORKDIR}/git"
 # Documentation depends on asciidoc, which we do not have, so
 # do not build documentation.
 SRC_URI += "file://disable-doc-creation.patch"
+
+# Workaround for upstream incompatibility with older Linux distros.
+# Relevant for us when compiling ima-evm-utils-native.
+SRC_URI += "file://evmctl.c-do-not-depend-on-xattr.h-with-IMA-defines.patch"

--- a/meta-security-smack/recipes-extended/libpam/libpam_%.bbappend
+++ b/meta-security-smack/recipes-extended/libpam/libpam_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 # Enable Smack support.
-DEPEND_append_smack = " smack"
+DEPENDS_append_smack = " smack"
 SRC_URI_append_smack = " file://pam-smack-so.patch"
 
 # Tizen has to patch several pam files in different packages (ssh, shadow).


### PR DESCRIPTION
Cathy ran into the libpam issue, for unknown reasons. She confirmed
that the (kinda obvious ;-) typo fix solves the issue.

Sasha confirmed that the ima-evm-utils patch works.
