### PR TITLE
keyutils: avoid QA warning about request-key-debug.sh

### DIFF
--- a/meta-integrity/recipes-security/keyutils/keyutils_1.5.8.bb
+++ b/meta-integrity/recipes-security/keyutils/keyutils_1.5.8.bb
@@ -38,6 +38,9 @@ DESTDIR=${D}"
 
 do_install() {
     cd ${S} && oe_runmake ${INSTALL_FLAGS} install
+
+    # Debugging script of unknown value, not packaged.
+    rm -f "${D}${datadir}/request-key-debug.sh"
 }
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
By removing the file from the staging, we avoid the following warning:
QA Issue: keyutils: Files/directories were installed but not shipped
  /usr/share/request-key-debug.sh [installed-vs-shipped]

This looks like a debugging script which is not really needed in
the image, so this looks like the simples solution. Adding it to
the keyutils-dbg pacckage would also work, but only if those
get generated, which is not guaranteed.

This fixes IOTOS-592.
