### PR TITLE
meta-security-smack tests: handling test binaries with iot test runner

### DIFF
--- a/meta-security-smack/lib/oeqa/runtime/smack.py
+++ b/meta-security-smack/lib/oeqa/runtime/smack.py
@@ -4,6 +4,7 @@ import os
 import string
 from oeqa.oetest import oeRuntimeTest, skipModule
 from oeqa.utils.decorators import *
+from oeqa.utils.helper import get_files_dir
 
 MAX_LABEL_LEN = 255
 LABEL = "a" * MAX_LABEL_LEN
@@ -432,8 +433,8 @@ class SmackEnforceMmap(SmackBasicTest):
         file_label="mmap_file_label"
         test_file = "/tmp/smack_test_mmap"
         print "mmap present: ", self.hasPackage("mmap-smack-test")
-        if not self.hasPackage("mmap-smack-test"):
-            self.skipTest("mmap_test binary not present") 
+        
+        self.target.copy_to(os.path.join(get_files_dir(), "mmap_test"), "/bin/")
 
         status, mmap_exe = self.target.run("which mmap_test")
         status, echo = self.target.run("which echo")
@@ -522,9 +523,9 @@ class SmackTcpSockets(SmackBasicTest):
 
         whole test takes places on image, depends on tcp_server/tcp_client'''
        
-        if not self.hasPackage("tcp-smack-test"):
-            self.skipTest("tcp smack binaries not present")       
-        
+        self.target.copy_to(os.path.join(get_files_dir(), "tcp_server"), "/bin/")
+        self.target.copy_to(os.path.join(get_files_dir(), "tcp_client"), "/bin/")
+
         status, output = self.target.run("ls /tmp/test_smack_tcp_sockets.sh")
         if status != 0:
             self.target.copy_to(
@@ -540,9 +541,8 @@ class SmackUdpSockets(SmackBasicTest):
 
         whole test takes places on image, depends on udp_server/udp_client'''
 
-        if not self.hasPackage("udp-smack-test"):
-            self.skipTest("udp smack binaries not present") 
-        
+        self.target.copy_to(os.path.join(get_files_dir(), "udp_client"), "/bin/")
+        self.target.copy_to(os.path.join(get_files_dir(), "udp_server"), "/bin/")
         status, output = self.target.run("ls /tmp/test_smack_udp_sockets.sh")
         if status != 0:
             self.target.copy_to(

--- a/meta-security-smack/recipes-test/images/iot-os-image.bbappend
+++ b/meta-security-smack/recipes-test/images/iot-os-image.bbappend
@@ -1,0 +1,1 @@
+EXTRA_IMAGEDEPENDS += "mmap-smack-test tcp-smack-test udp-smack-test"

--- a/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
+++ b/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
@@ -5,6 +5,9 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://mmap.c" 
 
+inherit copybin
+TARGET_FILES += "${WORKDIR}/mmap_test"
+
 S = "${WORKDIR}"
 do_compile() {
     ${CC} mmap.c -o mmap_test

--- a/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bb
+++ b/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bb
@@ -7,6 +7,9 @@ SRC_URI = "file://tcp_server.c \
            file://tcp_client.c \
 " 
 
+inherit copybin
+TARGET_FILES += "${WORKDIR}/tcp_client ${WORKDIR}/tcp_server"
+
 S = "${WORKDIR}"
 do_compile() {
     ${CC} tcp_client.c -o tcp_client

--- a/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bb
+++ b/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bb
@@ -7,6 +7,9 @@ SRC_URI = "file://udp_server.c \
            file://udp_client.c \
 " 
 
+inherit copybin
+TARGET_FILES += "${WORKDIR}/udp_client ${WORKDIR}/udp_server"
+
 S = "${WORKDIR}"
 do_compile() {
     ${CC} udp_client.c -o udp_client


### PR DESCRIPTION
Added files manifest and test manifest needed by iot test runner.
Modified the initial smack test to push binaries on image during
testing phase, not on build.
