### PR TITLE
meta-security-smack: Forward port pam-smack-so.patch to 1.2.x libpam

### DIFF
--- a/meta-security-smack/recipes-extended/libpam/libpam/pam-smack-so.patch
+++ b/meta-security-smack/recipes-extended/libpam/libpam/pam-smack-so.patch
@@ -16,10 +16,10 @@ Change-Id: I5a72fee29519d89d6b8ea60cd970d0438a0cb7cd
 Signed-off-by: Michael Leibowitz <michael.leibowitz@intel.com>
 ---
 
-diff --git a/configure.in b/configure.in
+diff --git a/configure.ac b/configure.ac
 index ae762a2..2749f0c 100644
---- a/configure.in
-+++ b/configure.in
+--- a/configure.ac
++++ b/configure.ac
 @@ -498,6 +498,9 @@ if test ! -z "$LIBSELINUX" ; then
      LIBS=$BACKUP_LIBS
  fi


### PR DESCRIPTION
libpam-1.2.% (upstream commit 7fbf54d6f4b67ed7bac04d801174ecfaa538c1a0)
pulled via openembedded-core master renamed configure.in to configure.ac.

pam-smack-so.patch provided by meta-security-smack layer tries to patch
non-existent configure.in and the build fails.

Forward port pam-smack-so.patch to 1.2.x libpam.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
