### PR TITLE
README.md files: document compatibility with Fido release branches

### DIFF
--- a/meta-integrity/README.md
+++ b/meta-integrity/README.md
@@ -10,11 +10,11 @@ Dependencies
 This layer depends on:
 
     URI: git://git.openembedded.org/bitbake
-    branch: master
+    branch: 1.26
 
     URI: git://git.openembedded.org/openembedded-core
     layers: meta
-    branch: master
+    branch: fido
 
 
 Patches

--- a/meta-security-framework/README.md
+++ b/meta-security-framework/README.md
@@ -10,15 +10,15 @@ Dependencies
 This layer depends on:
 
   URI: git://git.openembedded.org/bitbake
-  branch: master
+  branch: 1.26
 
   URI: git://git.openembedded.org/openembedded-core
   layers: meta
-  branch: master
+  branch: fido
 
   URI: git://github.com/01org/meta-intel-iot-security
   layers: security-smack
-  branch: master
+  branch: fido
 
 
 Patches

--- a/meta-security-smack/README.md
+++ b/meta-security-smack/README.md
@@ -10,11 +10,11 @@ Dependencies
 This layer depends on:
 
   URI: git://git.openembedded.org/bitbake
-  branch: master
+  branch: 1.26
 
   URI: git://git.openembedded.org/openembedded-core
   layers: meta
-  branch: master
+  branch: fido
 
 
 Patches


### PR DESCRIPTION
The "fido" branch of meta-intel-iot-security was only tested with the
"fido" branches of the layers it depends on. Compatibility with other
versions of these layers is either untested or known to not work
(security-smack's libpam patch does not apply to libpam in OE-core
master).

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
