### PR TITLE
security-manager: fix policy loading

### DIFF
--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -88,7 +88,7 @@ FILES_${PN}-policy = " \
 "
 RDEPENDS_${PN}-policy += "sqlite3 cynara"
 pkg_postinst_${PN}-policy () {
-   if [ x"$D" != "x" ] && ${bindir}/security-manager-policy-reload; then
+   if [ x"$D" = "x" ] && ${bindir}/security-manager-policy-reload; then
        exit 0
    else
        exit 1

--- a/meta-security-framework/recipes-security/security-manager/security-manager/security-manager-policy-reload-do-not-depend-on-GNU-.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/security-manager-policy-reload-do-not-depend-on-GNU-.patch
@@ -1,0 +1,35 @@
+From d2995014142306987bf86b4d508a84b9b4683c5c Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Wed, 19 Aug 2015 15:02:32 +0200
+Subject: [PATCH 2/2] security-manager-policy-reload: do not depend on GNU sed
+
+\U (= make replacement uppercase) is a GNU sed extension which is not
+supported by other sed implementation's (like the one from
+busybox). When using busybox, the bucket for user profiles became
+USER_TYPE_Uadmin instead USER_TYPE_ADMIN.
+
+To make SecurityManager more portable, better use tr to turn the
+bucket name into uppercase.
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+Upstream-Status: Submitted (https://github.com/Samsung/security-manager/pull/1
+
+---
+ policy/security-manager-policy-reload | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/policy/security-manager-policy-reload b/policy/security-manager-policy-reload
+index 274c49c..6f211c6 100755
+--- a/policy/security-manager-policy-reload
++++ b/policy/security-manager-policy-reload
+@@ -33,7 +33,7 @@ END
+ find "$POLICY_PATH" -name "usertype-*.profile" |
+ while read file
+ do
+-    bucket="`echo $file | sed -r 's|.*/usertype-(.*).profile$|USER_TYPE_\U\1|'`"
++    bucket="`echo $file | sed -r 's|.*/usertype-(.*).profile$|USER_TYPE_\1|' | tr '[:lower:]' '[:upper:]'`"
+ 
+     # Re-create the bucket with empty contents
+     cyad --delete-bucket=$bucket || true
+-- 
+2.1.4

--- a/meta-security-framework/recipes-security/security-manager/security-manager/systemd-stop-using-compat-libs.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/systemd-stop-using-compat-libs.patch
@@ -1,4 +1,4 @@
-From a273547ffb8ad131a3c80b8b2c9f0a8b5214c14e Mon Sep 17 00:00:00 2001
+From 8ec024d2adecb53029c6f1af2b95c93dfd43a7cb Mon Sep 17 00:00:00 2001
 From: Patrick Ohly <patrick.ohly@intel.com>
 Date: Tue, 24 Mar 2015 04:54:03 -0700
 Subject: [PATCH] systemd: stop using compat libs
@@ -9,16 +9,20 @@ by default).
 
 The code works fine with the current libsystemd, so just
 use that.
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+Upstream-Status: Submitted (https://github.com/Samsung/security-manager/pull/1
+
 ---
  src/common/CMakeLists.txt | 2 +-
  src/server/CMakeLists.txt | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/common/CMakeLists.txt b/src/common/CMakeLists.txt
-index cbcea64..317f389 100644
+index 2da9c3e..968c7c1 100644
 --- a/src/common/CMakeLists.txt
 +++ b/src/common/CMakeLists.txt
-@@ -3,7 +3,7 @@ SET(COMMON_VERSION ${COMMON_VERSION_MAJOR}.0.1)
+@@ -3,7 +3,7 @@ SET(COMMON_VERSION ${COMMON_VERSION_MAJOR}.0.2)
  
  PKG_CHECK_MODULES(COMMON_DEP
      REQUIRED
@@ -40,5 +44,4 @@ index 753eb96..6849d76 100644
  
  FIND_PACKAGE(Boost REQUIRED)
 -- 
-1.8.4.5
-
+2.1.4

--- a/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
+++ b/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
@@ -5,4 +5,7 @@ SRCREV = "860305a595d681d650024ad07b3b0977e1fcb0a6"
 SRC_URI += "git://github.com/Samsung/security-manager.git"
 S = "${WORKDIR}/git"
 
-SRC_URI += "file://systemd-stop-using-compat-libs.patch"
+SRC_URI += " \
+file://systemd-stop-using-compat-libs.patch \
+file://security-manager-policy-reload-do-not-depend-on-GNU-.patch \
+"


### PR DESCRIPTION
Initializing the Cynara DB did not work as intended for two reasons
(GNU sed dependency change the bucket names, and the script did not
really run). While at it, submit distro patches upstream and document
that.
