### PR TITLE
fix sstate and prserver issue

### DIFF
--- a/meta-integrity/README.md
+++ b/meta-integrity/README.md
@@ -94,7 +94,7 @@ layer:
     # does. Most likely the default attributes for these certificates
     # need to be adapted; modify the scripts as needed.
     cd $IMA_EVM_KEY_DIR
-    $IMA_EVM_BASE/scripts/ima-local-ca.priv
+    $IMA_EVM_BASE/scripts/ima-gen-local-ca.sh
     $IMA_EVM_BASE/scripts/ima-gen.sh
     exit
 

--- a/meta-integrity/conf/layer.conf
+++ b/meta-integrity/conf/layer.conf
@@ -10,7 +10,13 @@ BBFILE_COLLECTIONS += "integrity"
 BBFILE_PATTERN_integrity := "^${LAYERDIR}/"
 BBFILE_PRIORITY_integrity = "6"
 
-# Set a variable to get to the top of the metadata location,
-# needed for finding scripts and default debug keys.
+# Set a variable to get to the top of the metadata location. Needed
+# for finding scripts (when following the README.md instructions) and
+# default debug keys (in ima-evm-rootfs.bbclass).
 IMA_EVM_BASE := '${LAYERDIR}'
-export IMA_EVM_BASE
+
+# We must not export this path to all shell scripts (as in "export
+# IMA_EVM_BASE"), because that causes problems with sstate (becames
+# dependent on location of the layer). Exporting it to just the
+# interactive shell is enough.
+OE_TERMINAL_EXPORTS += "IMA_EVM_BASE"


### PR DESCRIPTION
Exporting the path to the layer to shell scripts causes problems with
sstate (not reusable when changing the location of the layer) and also
(?) with prserver (version going backwards).

While testing the replacement, I noticed that the README.md was
slightly wrong. Fixing that, too.
