### PR TITLE
smack: handle binary files with deploy-files

### DIFF
--- a/meta-security-smack/classes/deploy-files.bbclass
+++ b/meta-security-smack/classes/deploy-files.bbclass
@@ -1,0 +1,68 @@
+DEPLOY_FILES_DIR = "${WORKDIR}/deploy-files-${PN}"
+SSTATETASKS += "do_deploy_files"
+do_deploy_files[sstate-inputdirs] = "${DEPLOY_FILES_DIR}"
+do_deploy_files[sstate-outputdirs] = "${DEPLOY_DIR}/files/"
+
+python do_deploy_files_setscene () {
+    sstate_setscene(d)
+}
+addtask do_deploy_files_setscene
+do_deploy_files[dirs] = "${DEPLOY_FILES_DIR} ${B}"
+
+# Use like this:
+# DEPLOY_FILES = "abc xyz"
+# DEPLOY_FILES_FROM[abc] = "file-ab dir-c"
+# DEPLOY_FILES_TO[abc] = "directory-for-abc"
+# DEPLOY_FILES_FROM[xyz] = "file-xyz"
+# DEPLOY_FILES_TO[xyz] = "directory-for-xyz"
+#
+# The destination directory will be created inside
+# ${DEPLOYDIR}. The source files and directories
+# will be copied such that their name and (for
+# directories) the directory tree below it will
+# be preserved. Shell wildcards are supported.
+#
+# The default DEPLOY_FILES copies files for the native host
+# and the target into two different directories. Use that as follows:
+# DEPLOY_FILES_FROM_native = "native-file"
+# DEPLOY_FILES_FROM_target = "target-file"
+
+DEPLOY_FILES ?= "native target"
+DEPLOY_FILES_FROM[native] ?= ""
+DEPLOY_FILES_TO[native] = "native/${BUILD_ARCH}"
+DEPLOY_FILES_FROM[target] ?= ""
+DEPLOY_FILES_TO[target] = "target/${MACHINE}"
+
+# We have to use a Python function to access variable flags. Because
+# bitbake then does not know about the dependency on these variables,
+# we need to explicitly declare that. DEPLOYDIR may change without
+# invalidating the sstate, therefore it is not listed.
+do_deploy_files[vardeps] = "DEPLOY_FILES DEPLOY_FILES_FROM DEPLOY_FILES_TO"
+python do_deploy_files () {
+    import glob
+    import os
+    import shutil
+
+    for file in (d.getVar('DEPLOY_FILES', True) or '').split():
+        bb.note('file: %s' % file)
+        from_pattern = d.getVarFlag('DEPLOY_FILES_FROM', file, True)
+        bb.note('from: %s' % from_pattern)
+        if from_pattern:
+            to = os.path.join(d.getVar('DEPLOY_FILES_DIR', True), d.getVarFlag('DEPLOY_FILES_TO', file, True))
+            bb.note('to: %s' % to)
+            if not os.path.isdir(to):
+                os.makedirs(to)
+            for from_path in from_pattern.split():
+                for src in (glob.glob(from_path) or [from_path]):
+                    bb.note('Deploying %s to %s' % (src, to))
+                    if os.path.isdir(src):
+                        src_dirname = shutil._basename(src)
+                        to = os.path.join(to, src_dirname)
+                        if os.path.exists(to):
+                            bb.utils.remove(to, True)
+                        shutil.copytree(src, to)
+                    else:
+                        shutil.copy(src, to)
+}
+
+addtask deploy_files before do_build after do_compile

--- a/meta-security-smack/lib/oeqa/runtime/smack.py
+++ b/meta-security-smack/lib/oeqa/runtime/smack.py
@@ -5,6 +5,12 @@ import string
 from oeqa.oetest import oeRuntimeTest, skipModule
 from oeqa.utils.decorators import *
 
+def get_files_dir():
+    """Get directory of supporting files"""
+    pkgarch = oeRuntimeTest.tc.d.getVar('MACHINE', True)
+    deploydir = oeRuntimeTest.tc.d.getVar('DEPLOY_DIR', True)
+    return os.path.join(deploydir, "files", "target", pkgarch)
+
 MAX_LABEL_LEN = 255
 LABEL = "a" * MAX_LABEL_LEN
 
@@ -431,11 +437,8 @@ class SmackEnforceMmap(SmackBasicTest):
         mmap_label="mmap_label"
         file_label="mmap_file_label"
         test_file = "/tmp/smack_test_mmap"
-        print "mmap present: ", self.hasPackage("mmap-smack-test")
-        if not self.hasPackage("mmap-smack-test"):
-            self.skipTest("mmap_test binary not present") 
-
-        status, mmap_exe = self.target.run("which mmap_test")
+        self.target.copy_to(os.path.join(get_files_dir(), "mmap_test"), "/usr/bin/")
+        mmap_exe = "/usr/bin/mmap_test"
         status, echo = self.target.run("which echo")
         status, output = self.target.run("ls /tmp/notroot.py")
         if status != 0:
@@ -522,9 +525,8 @@ class SmackTcpSockets(SmackBasicTest):
 
         whole test takes places on image, depends on tcp_server/tcp_client'''
        
-        if not self.hasPackage("tcp-smack-test"):
-            self.skipTest("tcp smack binaries not present")       
-        
+        self.target.copy_to(os.path.join(get_files_dir(), "tcp_client"), "/usr/bin/")
+        self.target.copy_to(os.path.join(get_files_dir(), "tcp_server"), "/usr/bin/")
         status, output = self.target.run("ls /tmp/test_smack_tcp_sockets.sh")
         if status != 0:
             self.target.copy_to(
@@ -540,9 +542,8 @@ class SmackUdpSockets(SmackBasicTest):
 
         whole test takes places on image, depends on udp_server/udp_client'''
 
-        if not self.hasPackage("udp-smack-test"):
-            self.skipTest("udp smack binaries not present") 
-        
+        self.target.copy_to(os.path.join(get_files_dir(), "udp_client"), "/usr/bin/")
+        self.target.copy_to(os.path.join(get_files_dir(), "udp_server"), "/usr/bin/")
         status, output = self.target.run("ls /tmp/test_smack_udp_sockets.sh")
         if status != 0:
             self.target.copy_to(

--- a/meta-security-smack/recipes-test/image/iot-os-image.bbappend
+++ b/meta-security-smack/recipes-test/image/iot-os-image.bbappend
@@ -1,0 +1,1 @@
+EXTRA_IMAGEDEPENDS += "mmap-smack-test  tcp-smack-test  udp-smack-test"

--- a/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bbappend
+++ b/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bbappend
@@ -1,0 +1,2 @@
+inherit deploy-files
+DEPLOY_FILES_FROM[target] = "${WORKDIR}/mmap_test"

--- a/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bbappend
+++ b/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bbappend
@@ -1,0 +1,2 @@
+inherit deploy-files
+DEPLOY_FILES_FROM[target] = "${WORKDIR}/tcp_client ${WORKDIR}/tcp_server"

--- a/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bbappend
+++ b/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bbappend
@@ -1,0 +1,2 @@
+inherit deploy-files
+DEPLOY_FILES_FROM[target] = "${WORKDIR}/udp_client ${WORKDIR}/udp_server"


### PR DESCRIPTION
smack can maintain deploy-files.bbclass itself. then it shouldn't have inherit issue if this layer is referenced by other project.
