### PR TITLE
cynara+security-manager: debug mode

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -11,6 +11,11 @@ zip \
 # For testing:
 # DEPENDS += "gmock"
 
+PACKAGECONFIG ??= ""
+# Use debug mode to increase logging. Beware, also compiles with less optimization
+# and thus has to disable FORTIFY_SOURCE below.
+PACKAGECONFIG[debug] = "-DCMAKE_BUILD_TYPE=DEBUG,-DCMAKE_BUILD_TYPE=RELEASE,libunwind elfutils"
+
 inherit cmake
 
 CXXFLAGS_append = " \
@@ -19,11 +24,11 @@ CXXFLAGS_append = " \
 -DCYNARA_TESTS_DIR=\\\\\"${prefix}/share/cynara/tests/\\\\\" \
 -DCYNARA_CONFIGURATION_DIR=\\\\\"${sysconfdir}/cynara/\\\\\" \
 -DCYNARA_VERSION=\\\\\"${PV}\\\\\" \
+${@bb.utils.contains('PACKAGECONFIG', 'debug', '-Wp,-U_FORTIFY_SOURCE', '', d)} \
 "
 
 EXTRA_OECMAKE += " \
 -DCMAKE_VERBOSE_MAKEFILE=ON \
--DCMAKE_BUILD_TYPE=RELEASE \
 -DSYSTEMD_SYSTEM_UNITDIR=${systemd_unitdir}/system \
 "
 

--- a/meta-security-framework/recipes-security/cynara/cynara/chsgen-include-logging-code-in-debug-mode.patch
+++ b/meta-security-framework/recipes-security/cynara/cynara/chsgen-include-logging-code-in-debug-mode.patch
@@ -1,0 +1,50 @@
+From 6aed0431be279ccb58529f6e775349b91b8061ba Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Tue, 15 Sep 2015 15:36:06 +0200
+Subject: [PATCH] chsgen: include logging code in debug mode
+
+When building in debug mode, the log.h header file references
+code and (indirectly) libraries which we must add when linking
+chsgen.
+
+Upstream-Status: Submitted [https://github.com/Samsung/cynara/pull/11]
+
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ src/chsgen/CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/chsgen/CMakeLists.txt b/src/chsgen/CMakeLists.txt
+index 73c697f..cb0a15c 100644
+--- a/src/chsgen/CMakeLists.txt
++++ b/src/chsgen/CMakeLists.txt
+@@ -23,6 +23,18 @@ SET(CHSGEN_SOURCES
+     ${CHSGEN_PATH}/main.cpp
+     )
+ 
++IF (CMAKE_BUILD_TYPE MATCHES "DEBUG")
++SET(CHSGEN_SOURCES ${CHSGEN_SOURCES}
++    ${CYNARA_PATH}/common/log/Backtrace.cpp
++    ${CYNARA_PATH}/common/log/log.cpp
++    )
++
++SET(CHSGEN_DEP_LIBRARIES
++    ${CYNARA_DEP_LIBRARIES}
++    dw
++    )
++ENDIF (CMAKE_BUILD_TYPE MATCHES "DEBUG")
++
+ INCLUDE_DIRECTORIES(
+     ${CYNARA_PATH}
+     ${CYNARA_PATH}/include
+@@ -32,6 +44,7 @@ ADD_EXECUTABLE(${TARGET_CHSGEN} ${CHSGEN_SOURCES})
+ 
+ TARGET_LINK_LIBRARIES(${TARGET_CHSGEN}
+     crypt
++    ${CHSGEN_DEP_LIBRARIES}
+     )
+ 
+ INSTALL(TARGETS ${TARGET_CHSGEN} DESTINATION ${SBIN_INSTALL_DIR})
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/cynara/cynara_git.bb
+++ b/meta-security-framework/recipes-security/cynara/cynara_git.bb
@@ -12,4 +12,5 @@ file://cynara-db-migration-abort-on-errors.patch \
 file://cynara-db-migration-sysroot-support.patch \
 file://PolicyKeyFeature-avoid-complex-global-constants.patch \
 file://globals-avoid-copying-other-globals.patch \
+file://chsgen-include-logging-code-in-debug-mode.patch \
 "

--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -21,6 +21,9 @@ systemd \
 tizen-platform-config \
 "
 
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[debug] = "-DCMAKE_BUILD_TYPE=DEBUG,-DCMAKE_BUILD_TYPE=RELEASE"
+
 # TODO: get this from tizen-platform-config and adapt tizen-platform-config.
 TZ_SYS_DB = "/usr/dbspace"
 
@@ -28,7 +31,6 @@ EXTRA_OECMAKE = " \
 -DCMAKE_VERBOSE_MAKEFILE=ON \
 -DVERSION=${PV} \
 -DSYSTEMD_INSTALL_DIR=${systemd_unitdir}/system \
--DCMAKE_BUILD_TYPE=RELEASE \
 -DBIN_INSTALL_DIR=${bindir} \
 -DDB_INSTALL_DIR=${TZ_SYS_DB} \
 -DLIB_INSTALL_DIR=${libdir} \


### PR DESCRIPTION
For developers it is useful to enable additional logging and switch compile
flags such that debugging becomes easier. Needs to be enabled in local.conf.
