### PR TITLE
meta-integrity: make linux kernel patch depend on "ima" distro feature

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-%.bbappend
+++ b/meta-integrity/recipes-kernel/linux/linux-%.bbappend
@@ -1,11 +1,13 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/linux:"
+IMA_ENABLED_HERE := "${@'yes' if bb.data.inherits_class('kernel', d) and 'ima' in d.getVar('DISTRO_FEATURES', True).split() else 'no'}"
 
-IS_KERNEL_RECIPE := "${@bb.data.inherits_class('kernel', d) and 'yes' or 'no'}"
+IMA_FILESEXTRAPATHS_yes := "${THISDIR}/linux:"
+IMA_FILESEXTRAPATHS_no := ""
+FILESEXTRAPATHS_prepend := "${IMA_FILESEXTRAPATHS_${IMA_ENABLED_HERE}}"
 
 # Kernel config fragment enabling IMA/EVM
 IMA_EVM_CFG_yes = " file://ima.cfg"
 IMA_EVM_CFG_no = ""
-SRC_URI_append = "${IMA_EVM_CFG_${IS_KERNEL_RECIPE}}"
+SRC_URI_append = "${IMA_EVM_CFG_${IMA_ENABLED_HERE}}"
 
 # Put our x509 file into the build directory where the kernel
 # compilation will find it automatically. We use the build
@@ -20,5 +22,5 @@ do_compile_ima_evm_yes = "    [ '${IMA_EVM_ROOT_CA}' ] && cp '${IMA_EVM_ROOT_CA}
 do_compile_ima_evm_no = ":"
 
 do_compile_prepend () {
-${do_compile_ima_evm_${IS_KERNEL_RECIPE}}
+${do_compile_ima_evm_${IMA_ENABLED_HERE}}
 }


### PR DESCRIPTION
The goal for the layer is to have no effect unless IMA is explicitly
enabled. Changing the kernel configuration conditionally is an
important part of that. Not duplicating (and thus potentially replacing)
recipes from other layers is the other.
