### PR TITLE
cynara: DEPEND on glib-2.0

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327;beginlin
 
 DEPENDS = " \
 dbus \
+glib-2.0 \
 systemd \
 zip \
 "


### PR DESCRIPTION
cynara used to satisfy the glib-2.0 dependency indirectly through
systemd, but OE-core master recently removed that dependency from
systemd, so now we must declare it explicitly. It is cleaner that way,
too.

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
