### PR TITLE
Smacknet label configuration

### DIFF
--- a/meta-security-smack/recipes-extended/netvalue/files/netvalue.c
+++ b/meta-security-smack/recipes-extended/netvalue/files/netvalue.c
@@ -1,3 +1,32 @@
+/*
+ *               Copyright (c) 2012, 2013, Intel Corporation
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/meta-security-smack/recipes-extended/netvalue/files/netvalue.c
+++ b/meta-security-smack/recipes-extended/netvalue/files/netvalue.c
@@ -1,0 +1,31 @@
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <string.h>
+
+int main (void)
+{
+	struct ifaddrs *ifap, *ifa;
+    	struct sockaddr_in *saaddr,*samask;
+	struct in_addr netid;
+    	char addr[INET_ADDRSTRLEN],mask[INET_ADDRSTRLEN];
+	int prefix=0;
+    	getifaddrs (&ifap);
+    	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
+        	if (ifa->ifa_addr->sa_family==AF_INET) {
+            		saaddr = (struct sockaddr_in *) ifa->ifa_addr;
+            		samask = (struct sockaddr_in *) ifa->ifa_netmask;
+			strncpy(addr,inet_ntoa(saaddr->sin_addr),sizeof(addr));
+            		strncpy(mask,inet_ntoa(samask->sin_addr),sizeof(mask));
+			netid.s_addr=(saaddr->sin_addr.s_addr & samask->sin_addr.s_addr);
+			prefix=__builtin_popcount(samask->sin_addr.s_addr);	
+            		printf("Interface: %s\tAddress: %s\tMask: %s\tNetwork: %s\tPrefix: /%d\n",
+				 ifa->ifa_name,addr,mask,inet_ntoa(netid),prefix);
+        	}
+    	}
+
+    	freeifaddrs(ifap);
+    	return 0;
+}

--- a/meta-security-smack/recipes-extended/netvalue/netvalue_0.1.bb
+++ b/meta-security-smack/recipes-extended/netvalue/netvalue_0.1.bb
@@ -1,0 +1,18 @@
+SUMMARY = "IP network information Display"
+
+# this license is temporary and it will be reviewed under sdl process
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+
+
+BBCLASSEXTEND = "native"
+SRC_URI += "file://netvalue.c"
+
+do_compile(){
+        ${CC} -o netvalue ../netvalue.c
+}
+
+do_install(){
+        install -d ${D}${bindir}
+        install -m 551 netvalue ${D}${bindir}/netvalue
+}

--- a/meta-security-smack/recipes-extended/smacknet/files/smacknet
+++ b/meta-security-smack/recipes-extended/smacknet/files/smacknet
@@ -1,0 +1,49 @@
+#!/bin/bash
+#############################################################################
+#          Copyright (c) 2012, 2013, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of Intel Corporation nor the names of its contributors
+#      may be used to endorse or promote products derived from this software
+#      without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+################################################################################
+
+
+#  Set the netlabel values in the smackfs netlabel
+#  Set the Smack rules for System for Network::Cloud
+#  Set the Smack rules for System for Network::Local
+
+while true; do
+ if [ -f /sys/fs/smackfs/load2 ] 
+ then
+  LOCALNET=`netvalue | grep -v lo | awk '{print $8$10}'`
+  echo $LOCALNET Network::Local > /sys/fs/smackfs/netlabel
+  echo 0.0.0.0/0 Network::Cloud > /sys/fs/smackfs/netlabel
+  echo 127.0.0.0/8 -CIPSO > /sys/fs/smackfs/netlabel
+  echo System Network::Cloud w > /sys/fs/smackfs/load2
+  echo System Network::Local w > /sys/fs/smackfs/load2
+  echo Network::Cloud System w > /sys/fs/smackfs/load2
+  echo Network::Local System w > /sys/fs/smackfs/load2
+ fi
+ sleep 300
+done

--- a/meta-security-smack/recipes-extended/smacknet/files/smacknet.service
+++ b/meta-security-smack/recipes-extended/smacknet/files/smacknet.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=netlabels configuration for SMACK
+Wants=network.target network-online.target
+After=network.target network-online.target
+
+[Service]
+TimeoutStartSec=0
+ExecStart=@BINDIR@/smacknet
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-security-smack/recipes-extended/smacknet/smacknet.bb
+++ b/meta-security-smack/recipes-extended/smacknet/smacknet.bb
@@ -1,0 +1,26 @@
+#SMACKNET Description
+SUMMARY = "Smack network labels configuration"
+DESCRIPTION = "Provide service that will be labeling the network rules"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+RDEPENDS_${PN} = "netvalue bash"
+
+SRC_URI += "file://smacknet \
+        file://smacknet.service \
+	"
+S = "${WORKDIR}"
+
+inherit systemd
+
+#netlabel configuration service
+SYSTEMD_SERVICE_${PN} = "smacknet.service"
+
+do_install(){
+        install -d ${D}${bindir}
+        install -m 0551 ${WORKDIR}/smacknet ${D}${bindir}
+
+        install -d -m 755 ${D}${systemd_unitdir}/system
+        install -m 551 ${WORKDIR}/smacknet.service ${D}${systemd_unitdir}/system
+        sed -i -e 's,@BINDIR@,${bindir},g' ${D}${systemd_unitdir}/system/smacknet.service
+}
+   


### PR DESCRIPTION
Related-to: IOTOS-771 IOTOS-807 IOTOS-808.
Provide network configuration to netlabel  for Smack.

Signed-off-by: Alejandro Joya alejandro.joya.cruz@intel.com
