### PR TITLE
Create packagegroups for easier package management

### DIFF
--- a/meta-integrity/recipes-core/packagegroups/packagegroup-ima-evm-utils.bb
+++ b/meta-integrity/recipes-core/packagegroups/packagegroup-ima-evm-utils.bb
@@ -1,0 +1,9 @@
+SUMMARY = "IMA/EVM userspace tools"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+# Only one at the moment, but perhaps more will come in the future.
+RDEPENDS_${PN} = " \
+    ima-evm-utils \
+"

--- a/meta-security-framework/recipes-core/packagegroups/packagegroup-security-framework.bb
+++ b/meta-security-framework/recipes-core/packagegroups/packagegroup-security-framework.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Security middleware components"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+# Install Cynara and security-manager by default if (and only if)
+# Smack is enabled.
+#
+# Cynara does not have a hard dependency on Smack security,
+# but is meant to be used with it. security-manager however
+# links against smack-userspace and expects Smack to be active,
+# so we do not have any choice.
+#
+# Without configuration, security-manager is not usable. We use
+# the policy packaged from the upstream source code here. Adapting
+# it for the distro can be done by patching that source.
+RDEPENDS_${PN}_append_smack = " \
+    cynara \
+    security-manager \
+    security-manager-policy \
+"


### PR DESCRIPTION
Create two new package groups: one for security-framework and another for ima-evm-utils.
