### PR TITLE
smacknet: correct permissions for smacknet.service.

### DIFF
--- a/meta-security-framework/recipes-security/smacknet/smacknet.bb
+++ b/meta-security-framework/recipes-security/smacknet/smacknet.bb
@@ -20,7 +20,7 @@ do_install(){
         install -m 0551 ${WORKDIR}/smacknet ${D}${bindir}
 
         install -d -m 755 ${D}${systemd_unitdir}/system
-        install -m 551 ${WORKDIR}/smacknet.service ${D}${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/smacknet.service ${D}${systemd_unitdir}/system
         sed -i -e 's,@BINDIR@,${bindir},g' ${D}${systemd_unitdir}/system/smacknet.service
 }
    


### PR DESCRIPTION
Systemd would like service files to be
    a) non-executable and
    b) world-readable (since API allows it anyway).

Change the service file permission from 551 to 644.
