### PR TITLE
mmap-smack-test: Add correct license.

### DIFF
--- a/meta-security-smack/recipes-test/mmap-smack-test/files/LICENSE
+++ b/meta-security-smack/recipes-test/mmap-smack-test/files/LICENSE
@@ -1,0 +1,19 @@
+Permission is granted to make and distribute verbatim copies of this
+manual provided the copyright notice and this permission notice are
+preserved on all copies.
+
+Permission is granted to copy and distribute modified versions of this
+manual under the conditions for verbatim copying, provided that the
+entire resulting derived work is distributed under the terms of a
+permission notice identical to this one.
+
+Since the Linux kernel and libraries are constantly changing, this
+manual page may be incorrect or out-of-date.  The author(s) assume no
+responsibility for errors or omissions, or for damages resulting from
+the use of the information contained herein.  The author(s) may not
+have taken the same level of care in the production of this manual,
+which is licensed free of charge, as they might when working
+professionally.
+
+Formatted or processed versions of this manual, if unaccompanied by
+the source, must acknowledge the copyright and authors of this work.

--- a/meta-security-smack/recipes-test/mmap-smack-test/files/mmap.c
+++ b/meta-security-smack/recipes-test/mmap-smack-test/files/mmap.c
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 1996 Andries Brouwer <aeb@cwi.nl>
+and Copyright (C) 2006, 2007 Michael Kerrisk <mtk.manpages@gmail.com>
+*/
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
+++ b/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
@@ -1,9 +1,10 @@
 SUMMARY = "Mmap binary used to test smack mmap attribute"
 DESCRIPTION = "Mmap binary used to test smack mmap attribute"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "VERBATIM"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=52d0f7188d92ede618092599653e0a63"
+NO_GENERIC_LICENSE[VERBATIM] = "1"
 
-SRC_URI = "file://mmap.c" 
+SRC_URI = "file://mmap.c file://LICENSE" 
 
 S = "${WORKDIR}"
 do_compile() {


### PR DESCRIPTION
Fix license issue by adding the correct verbatim license, as
seen in the man pages of mmap
