### PR TITLE
smacknet: add User network Privileges

### DIFF
--- a/meta-security-framework/recipes-security/smacknet/files/smacknet
+++ b/meta-security-framework/recipes-security/smacknet/files/smacknet
@@ -44,6 +44,11 @@ while true; do
   echo System Network::Local w > /sys/fs/smackfs/load2
   echo Network::Cloud System w > /sys/fs/smackfs/load2
   echo Network::Local System w > /sys/fs/smackfs/load2
+  
+  echo User Network::Cloud w > /sys/fs/smackfs/load2
+  echo User Network::Local w > /sys/fs/smackfs/load2
+  echo Network::Cloud User w > /sys/fs/smackfs/load2
+  echo Network::Local User w > /sys/fs/smackfs/load2
  fi
  sleep 300
 done


### PR DESCRIPTION
Ref-to: IOTOS-1014
User should have the same Write Privileges to the network as
already is based on System.

This will allow to the User label in smack to the local and
cloud network.

Signed-off-by: Alejandro Joya alejandro.joya.cruz@intel.com
