### PR TITLE
smacknet: disable service

### DIFF
--- a/meta-security-framework/recipes-security/smacknet/smacknet.bb
+++ b/meta-security-framework/recipes-security/smacknet/smacknet.bb
@@ -14,7 +14,7 @@ inherit systemd
 
 #netlabel configuration service
 SYSTEMD_SERVICE_${PN} = "smacknet.service"
-
+SYSTEMD_AUTO_ENABLE = "disable"
 do_install(){
         install -d ${D}${bindir}
         install -m 0551 ${WORKDIR}/smacknet ${D}${bindir}


### PR DESCRIPTION
it disable the service and not set up the smack netlabels

Fixes: IOTOS-1014
Signed-off-by: Alejandro Joya alejandro.joya.cruz@intel.com
