### PR TITLE
smack tests: Updated notroot.py to set up uid and process label

### DIFF
--- a/meta-security-smack/lib/oeqa/runtime/files/notroot.py
+++ b/meta-security-smack/lib/oeqa/runtime/files/notroot.py
@@ -3,14 +3,18 @@
 import os
 import sys
 
-os.setuid(1)
-
 try:
-    path=sys.argv[1]
-    sys.argv.pop(0)
-    os.execv(path,sys.argv)
-except Exception,e:
-    print e.message
-    sys.exit(1)
+	uid = int(sys.argv[1])
+	sys.argv.pop(1)
+	label = sys.argv[1]
+	sys.argv.pop(1)
+	open("/proc/self/attr/current", "w").write(label)
+	path=sys.argv[1]
+	sys.argv.pop(0)
+	os.setgid(uid)
+	os.setuid(uid)	
+	os.execv(path,sys.argv)
 
-sys.exit(0)
+except Exception,e:
+	print e.message
+	sys.exit(1)

--- a/meta-security-smack/lib/oeqa/runtime/files/smack_test_file_access.sh
+++ b/meta-security-smack/lib/oeqa/runtime/files/smack_test_file_access.sh
@@ -6,8 +6,9 @@ TMP="/tmp"
 test_file=$TMP/smack_test_access_file
 CAT=`which cat`
 ECHO=`which echo`
-
-python $TMP/notroot.py $ECHO 'TEST' > $test_file
+uid=1000
+initial_label=`cat /proc/self/attr/current`
+python $TMP/notroot.py $uid "TheOther" $ECHO 'TEST' > $test_file
 chsmack -a "TheOther" $test_file
 
 #        12345678901234567890123456789012345678901234567890123456
@@ -16,22 +17,16 @@ rule_ro="TheOne                  TheOther                r----"
 
 # Remove pre-existent rules for "TheOne TheOther <access>"
 echo -n "$delrule" > $SMACK_PATH/load
-initial_label=`cat /proc/self/attr/current`
-echo "TheOne" >/proc/self/attr/current
-python $TMP/notroot.py $CAT $test_file 2>&1 1>/dev/null | grep -q "Permission denied" || RC=$?
+python $TMP/notroot.py $uid "TheOne" $CAT $test_file 2>&1 1>/dev/null | grep -q "Permission denied" || RC=$?
 if [ $RC -ne 0 ]; then
-	# restore proper label
-	echo $initial_label >/proc/self/attr/current
 	echo "Process with different label than the test file and no read access on it can read it"
 	exit $RC
 fi
 
 # adding read access
 echo -n "$rule_ro" > $SMACK_PATH/load
-python $TMP/notroot.py $CAT $test_file | grep -q "TEST" || RC=$?
+python $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
 if [ $RC -ne 0 ]; then
-	# restore proper label
-	echo $initial_label >/proc/self/attr/current
 	echo "Process with different label than the test file but with read access on it cannot read it"
 	exit $RC
 fi
@@ -41,27 +36,17 @@ echo -n "$delrule" > $SMACK_PATH/load
 # changing label of test file to *
 # according to SMACK documentation, read access on a * object is always permitted
 chsmack -a '*' $test_file
-python $TMP/notroot.py $CAT $test_file | grep -q "TEST" || RC=$?
+python $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
 if [ $RC -ne 0 ]; then
-	# restore proper label
-	echo $initial_label >/proc/self/attr/current
 	echo  "Process cannot read file with * label"
 	exit $RC
 fi
 
-# restore proper label
-echo $initial_label >/proc/self/attr/current
-# adding read access
-echo -n "$rule_ro" > $SMACK_PATH/load
 # changing subject label to *
 # according to SMACK documentation, every access requested by a star labeled subject is rejected
-test_sh=$TMP/smack_test.sh
-echo '#!/bin/bash' > $test_sh
-echo "cat $test_file" >> $test_sh
-chmod +x $test_sh
-chsmack -e '*' $test_sh
-chsmack -a "test" $test_file
-python $TMP/notroot.py $test_sh 2>&1 1>/dev/null | grep -q "Permission denied" || RC=$?
+TOUCH=`which touch`
+python $TMP/notroot.py $uid '*' $TOUCH $TMP/test_file_2
+ls -la $TMP/test_file_2 2>&1 | grep -q 'No such file or directory' || RC=$?
 if [ $RC -ne 0 ];then
 	echo "Process with label '*' should not have any access"
 	exit $RC


### PR DESCRIPTION
Notroot.py now takes as argument an uid for the process to run as,
along with a label for it. Updated smack.py and bash scripts using
notroot.py
