### PR TITLE
cynara: patch fixes library install path

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -21,7 +21,7 @@ inherit cmake
 
 CXXFLAGS_append = " \
 -DCYNARA_STATE_PATH=\\\\\"${localstatedir}/cynara/\\\\\" \
--DCYNARA_LIB_PATH=\\\\\"${prefix}/lib/cynara/\\\\\" \
+-DCYNARA_LIB_PATH=\\\\\"${libdir}/cynara/\\\\\" \
 -DCYNARA_TESTS_DIR=\\\\\"${prefix}/share/cynara/tests/\\\\\" \
 -DCYNARA_CONFIGURATION_DIR=\\\\\"${sysconfdir}/cynara/\\\\\" \
 -DCYNARA_VERSION=\\\\\"${PV}\\\\\" \
@@ -31,6 +31,7 @@ ${@bb.utils.contains('PACKAGECONFIG', 'debug', '-Wp,-U_FORTIFY_SOURCE', '', d)} 
 EXTRA_OECMAKE += " \
 -DCMAKE_VERBOSE_MAKEFILE=ON \
 -DSYSTEMD_SYSTEM_UNITDIR=${systemd_unitdir}/system \
+-DCMAKE_INSTALL_LIBDIR=${libdir} \
 "
 
 # Explicitly package empty directory. Otherwise Cynara prints warnings

--- a/meta-security-framework/recipes-security/cynara/cynara/0001-cmake-don-t-hardcode-libdir.patch
+++ b/meta-security-framework/recipes-security/cynara/cynara/0001-cmake-don-t-hardcode-libdir.patch
@@ -1,0 +1,25 @@
+From 247f8e0136acd23def711b6094ff99760f39d554 Mon Sep 17 00:00:00 2001
+From: Kevron Rees <kevron.m.rees@intel.com>
+Date: Wed, 28 Oct 2015 13:07:38 -0700
+Subject: [PATCH] cmake: don't hardcode libdir
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 513f103..868ad8b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,7 +31,7 @@ INCLUDE(CheckCXXCompilerFlag)
+ #############################  install dirs  ##################################
+ 
+ SET(LIB_INSTALL_DIR
+-    "${CMAKE_INSTALL_PREFIX}/lib"
++    "${CMAKE_INSTALL_LIBDIR}"
+     CACHE PATH
+     "Library installation directory")
+ 
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/cynara/cynara_git.bb
+++ b/meta-security-framework/recipes-security/cynara/cynara_git.bb
@@ -13,4 +13,5 @@ file://cynara-db-migration-sysroot-support.patch \
 file://PolicyKeyFeature-avoid-complex-global-constants.patch \
 file://globals-avoid-copying-other-globals.patch \
 file://chsgen-include-logging-code-in-debug-mode.patch \
+file://0001-cmake-don-t-hardcode-libdir.patch \
 "


### PR DESCRIPTION
cynara doesn't compile with multilib because it contains a hardcoded library install
path.  This patch fixes that.

Upstream Status: submitted to cynara master
