### PR TITLE
Security-manager: add custom rules set for smack

### DIFF
--- a/meta-security-framework/recipes-security/security-manager/security-manager/0001-Smack-rules-create-two-new-functions.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/0001-Smack-rules-create-two-new-functions.patch
@@ -1,0 +1,116 @@
+From d130a7384428a96f31ad5950ffbffadc0aa29a15 Mon Sep 17 00:00:00 2001
+From: Alejandro Joya <alejandro.joya.cruz@intel.com>
+Date: Wed, 4 Nov 2015 19:01:35 -0600
+Subject: [PATCH 1/2] Smack-rules: create two new functions
+
+It let to smack-rules to create multiple set of rules
+related with the privileges.
+
+It runs from the same bases than for a static set of rules on the
+template, but let you add 1 or many templates for different cases.
+
+Signed-off-by: Alejandro Joya <alejandro.joya.cruz@intel.com>
+---
+ src/common/include/smack-rules.h | 15 ++++++++++++++
+ src/common/smack-rules.cpp       | 44 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 59 insertions(+)
+
+diff --git a/src/common/include/smack-rules.h b/src/common/include/smack-rules.h
+index 91446a7..f9fa438 100644
+--- a/src/common/include/smack-rules.h
++++ b/src/common/include/smack-rules.h
+@@ -47,6 +47,8 @@ public:
+     void addFromTemplate(const std::vector<std::string> &templateRules,
+         const std::string &appId, const std::string &pkgId);
+     void addFromTemplateFile(const std::string &appId, const std::string &pkgId);
++    void addFromTemplateFile(const std::string &appId, const std::string &pkgId,
++	const std::string &path);
+ 
+     void apply() const;
+     void clear() const;
+@@ -75,6 +77,19 @@ public:
+     static void installApplicationRules(const std::string &appId, const std::string &pkgId,
+         const std::vector<std::string> &pkgContents);
+     /**
++     * Install privileges-specific smack rules.
++     *
++     * Function creates smack rules using predefined template. Rules are applied
++     * to the kernel and saved on persistent storage so they are loaded on system boot.
++     *
++     * @param[in] appId - application id that is beeing installed
++     * @param[in] pkgId - package id that the application is in
++     * @param[in] pkgContents - a list of all applications in the package
++     * @param[in] privileges - a list of all prvileges 
++     */
++    static void installApplicationPrivilegesRules(const std::string &appId, const std::string &pkgId,
++        const std::vector<std::string> &pkgContents, const std::vector<std::string> &privileges);
++    /**
+      * Uninstall package-specific smack rules.
+      *
+      * Function loads package-specific smack rules, revokes them from the kernel
+diff --git a/src/common/smack-rules.cpp b/src/common/smack-rules.cpp
+index 3629e0f..d834e42 100644
+--- a/src/common/smack-rules.cpp
++++ b/src/common/smack-rules.cpp
+@@ -135,6 +135,29 @@ void SmackRules::saveToFile(const std::string &path) const
+     }
+ }
+ 
++void SmackRules::addFromTemplateFile(const std::string &appId,
++        const std::string &pkgId, const std::string &path)
++{
++    std::vector<std::string> templateRules;
++    std::string line;
++    std::ifstream templateRulesFile(path);
++
++    if (!templateRulesFile.is_open()) {
++        LogError("Cannot open rules template file: " << path);
++        ThrowMsg(SmackException::FileError, "Cannot open rules template file: " << path);
++    }
++
++    while (std::getline(templateRulesFile, line)) {
++        templateRules.push_back(line);
++    }
++
++    if (templateRulesFile.bad()) {
++        LogError("Error reading template file: " << APP_RULES_TEMPLATE_FILE_PATH);
++        ThrowMsg(SmackException::FileError, "Error reading template file: " << APP_RULES_TEMPLATE_FILE_PATH);
++    }
++
++    addFromTemplate(templateRules, appId, pkgId);
++}
+ 
+ void SmackRules::addFromTemplateFile(const std::string &appId,
+         const std::string &pkgId)
+@@ -223,7 +246,28 @@ std::string SmackRules::getApplicationRulesFilePath(const std::string &appId)
+     std::string path(tzplatform_mkpath3(TZ_SYS_SMACK, "accesses.d", ("app_" +  appId).c_str()));
+     return path;
+ }
++void SmackRules::installApplicationPrivilegesRules(const std::string &appId, const std::string &pkgId,
++        const std::vector<std::string> &pkgContents, const std::vector<std::string> &privileges)
++{
++    SmackRules smackRules;
++    std::string appPath = getApplicationRulesFilePath(appId);
++    smackRules.loadFromFile(appPath);
++    struct stat buffer;
++    for (auto privilege : privileges) {
++        if (privilege.empty())
++            continue;
++        std::string fprivilege ( privilege + "-template.smack");
++        std::string path(tzplatform_mkpath4(TZ_SYS_SHARE, "security-manager", "policy", fprivilege.c_str()));
++        if( stat(path.c_str(), &buffer) == 0) 
++            smackRules.addFromTemplateFile(appId, pkgId, path);
++    }
++
++    if (smack_smackfs_path() != NULL)
++        smackRules.apply();
+ 
++    smackRules.saveToFile(appPath);
++    updatePackageRules(pkgId, pkgContents);
++}
+ void SmackRules::installApplicationRules(const std::string &appId, const std::string &pkgId,
+         const std::vector<std::string> &pkgContents)
+ {
+-- 
+2.1.0
+

--- a/meta-security-framework/recipes-security/security-manager/security-manager/0002-app-install-implement-multiple-set-of-smack-rules.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/0002-app-install-implement-multiple-set-of-smack-rules.patch
@@ -1,0 +1,34 @@
+From 19688cbe2ca10921a499f3fa265928dca54cf98d Mon Sep 17 00:00:00 2001
+From: Alejandro Joya <alejandro.joya.cruz@intel.com>
+Date: Wed, 4 Nov 2015 19:06:23 -0600
+Subject: [PATCH 2/2] app-install: implement multiple set of smack-rules
+
+If it's need it could create load multiple set of smack rules
+related with the privileges.
+It wouldn't affect the case that only the default set of rules is need it.
+
+Signed-off-by: Alejandro Joya <alejandro.joya.cruz@intel.com>
+---
+ src/common/service_impl.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/common/service_impl.cpp b/src/common/service_impl.cpp
+index 7fd621c..ae305d3 100644
+--- a/src/common/service_impl.cpp
++++ b/src/common/service_impl.cpp
+@@ -338,6 +338,12 @@ int appInstall(const app_inst_req &req, uid_t uid)
+         LogDebug("Adding Smack rules for new appId: " << req.appId << " with pkgId: "
+                 << req.pkgId << ". Applications in package: " << pkgContents.size());
+         SmackRules::installApplicationRules(req.appId, req.pkgId, pkgContents);
++	/*Setup for privileges custom rules*/
++	 LogDebug("Adding Smack rules for new appId: " << req.appId << " with pkgId: "
++                << req.pkgId << ". Applications in package: " << pkgContents.size()
++		<< " and Privileges");
++	SmackRules::installApplicationPrivilegesRules(req.appId, req.pkgId,
++	    pkgContents,req.privileges);
+     } catch (const SmackException::Base &e) {
+         LogError("Error while applying Smack policy for application: " << e.DumpToString());
+         return SECURITY_MANAGER_API_ERROR_SETTING_FILE_LABEL_FAILED;
+-- 
+2.1.0
+

--- a/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
+++ b/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
@@ -8,4 +8,6 @@ S = "${WORKDIR}/git"
 SRC_URI += " \
 file://systemd-stop-using-compat-libs.patch \
 file://security-manager-policy-reload-do-not-depend-on-GNU-.patch \
+file://0001-Smack-rules-create-two-new-functions.patch \
+file://0002-app-install-implement-multiple-set-of-smack-rules.patch \
 "


### PR DESCRIPTION
Now security manager will offer the chance to add multiple custom
set of smack rules related to the privileges that it will add it.

If the privileges doesn't apply new rules it will only apply
the default smack rules.

Related-to: IOTOS-807 IOTOS-808.
Signed-off-by: Alejandro Joya alejandro.joya.cruz@intel.com
