### PR TITLE
Security-manager: re-enable custom rules set for smack

### DIFF
--- a/meta-security-framework/recipes-security/smacknet/smacknet.bb
+++ b/meta-security-framework/recipes-security/smacknet/smacknet.bb
@@ -14,7 +14,7 @@ inherit systemd
 
 #netlabel configuration service
 SYSTEMD_SERVICE_${PN} = "smacknet.service"
-SYSTEMD_AUTO_ENABLE = "disable"
+SYSTEMD_AUTO_ENABLE = "enable"
 do_install(){
         install -d ${D}${bindir}
         install -m 0551 ${WORKDIR}/smacknet ${D}${bindir}


### PR DESCRIPTION
Now security manager will offer the chance to add multiple custom
set of smack rules related to the privileges that it will add it.

If the privileges doesn't apply new rules it will only apply
the default smack rules.

Related-to: IOTOS-807 IOTOS-808.

Signed-off-by: John L. Whiteman john.l.whiteman@intel.com
