### PR TITLE
IMA: exclude efivars fs

### DIFF
--- a/meta-integrity/data/ima_policy_appraise_all
+++ b/meta-integrity/data/ima_policy_appraise_all
@@ -23,5 +23,7 @@ dont_appraise fsmagic=0x73636673
 dont_appraise fsmagic=0xf97cff8c
 # NSFS_MAGIC (introduced in 3.19, see cd025f7 and e149ed2 in the upstream Linux kernel)
 dont_appraise fsmagic=0x6e736673
+# EFIVARFS_MAGIC
+dont_appraise fsmagic=0xde5e81e4
 
 appraise

--- a/meta-integrity/data/ima_policy_hashed
+++ b/meta-integrity/data/ima_policy_hashed
@@ -53,6 +53,9 @@ dont_measure fsmagic=0x43415d53
 # CGROUP_SUPER_MAGIC
 dont_appraise fsmagic=0x27e0eb
 dont_measure fsmagic=0x27e0eb
+# EFIVARFS_MAGIC
+dont_appraise fsmagic=0xde5e81e4
+dont_measure fsmagic=0xde5e81e4
 
 # Special partition, no checking done.
 # dont_measure  fsuuid=a11234...


### PR DESCRIPTION
/sys/firmware/efi/efivars is another special directory where the
underlying filesystem does not have the necessary security xattrs.  We
must exclude it, otherwise access to EFI variables is prevented, which
affects, for example, systemd-analyze because it needs to read some
variables
(http://www.freedesktop.org/wiki/Software/systemd/BootLoaderInterface/).

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
