### PR TITLE
security-manager: removes use of deprecated std::auto_ptr

### DIFF
--- a/meta-security-framework/recipes-security/security-manager/security-manager/c-11-replace-depracated-auto_ptr.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/c-11-replace-depracated-auto_ptr.patch
@@ -1,0 +1,32 @@
+From 6abeec29a0e704f4bf7084b29275b99fea0a78de Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Bollo?= <jobol@nonadev.net>
+Date: Wed, 13 Jan 2016 17:30:06 +0100
+Subject: [PATCH 2/2] c++11: replace depracated auto_ptr
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream-Status: Submitted [https://review.tizen.org/gerrit/#/c/56940/]
+
+Change-Id: Id793c784c9674eef48f346226c094bdd9f7bbda8
+Signed-off-by: José Bollo <jobol@nonadev.net>
+---
+ src/dpl/core/include/dpl/binary_queue.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dpl/core/include/dpl/binary_queue.h b/src/dpl/core/include/dpl/binary_queue.h
+index dd03f5e..185b6c7 100644
+--- a/src/dpl/core/include/dpl/binary_queue.h
++++ b/src/dpl/core/include/dpl/binary_queue.h
+@@ -33,7 +33,7 @@ namespace SecurityManager {
+  * Binary queue auto pointer
+  */
+ class BinaryQueue;
+-typedef std::auto_ptr<BinaryQueue> BinaryQueueAutoPtr;
++typedef std::unique_ptr<BinaryQueue> BinaryQueueAutoPtr;
+ 
+ /**
+  * Binary stream implemented as constant size bucket list
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
+++ b/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
@@ -10,6 +10,7 @@ file://systemd-stop-using-compat-libs.patch \
 file://security-manager-policy-reload-do-not-depend-on-GNU-.patch \
 file://0001-Smack-rules-create-two-new-functions.patch \
 file://0002-app-install-implement-multiple-set-of-smack-rules.patch \
+file://c-11-replace-depracated-auto_ptr.patch \
 "
 
 ##########################################


### PR DESCRIPTION
This fixes a fatal error when compiling with gcc 5.0 because auto_ptr is deprecated.

Signed-off-by: José Bollo jose.bollo@iot.bzh
