### PR TITLE
security-manager: drop tizen specific dependency

### DIFF
--- a/meta-security-framework/recipes-security/security-manager/security-manager/socket-manager-removes-tizen-specific-call.patch
+++ b/meta-security-framework/recipes-security/security-manager/security-manager/socket-manager-removes-tizen-specific-call.patch
@@ -1,0 +1,47 @@
+From 75c4852e47217ab85d6840b488ab4b3688091856 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Bollo?= <jose.bollo@iot.bzh>
+Date: Fri, 8 Jan 2016 16:53:46 +0100
+Subject: [PATCH 1/2] socket-manager: removes tizen specific call
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The function 'smack_fgetlabel' is specific to Tizen
+and is no more maintained upstream.
+
+Upstream-Status: Accepted [https://review.tizen.org/gerrit/#/c/56507/]
+
+Change-Id: I3802742b1758efe37b33e6d968ff727d68f2fd1f
+Signed-off-by: José Bollo <jobol@nonadev.net>
+---
+ src/server/main/socket-manager.cpp | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/server/main/socket-manager.cpp b/src/server/main/socket-manager.cpp
+index 0366186..c5cec18 100644
+--- a/src/server/main/socket-manager.cpp
++++ b/src/server/main/socket-manager.cpp
+@@ -30,6 +30,7 @@
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <sys/smack.h>
++#include <linux/xattr.h>
+ #include <sys/un.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+@@ -500,9 +501,9 @@ int SocketManager::CreateDomainSocketHelp(
+     if (smack_check()) {
+         LogInfo("Set up smack label: " << desc.smackLabel);
+ 
+-        if (0 != smack_fsetlabel(sockfd, desc.smackLabel.c_str(), SMACK_LABEL_IPIN)) {
+-            LogError("Error in smack_fsetlabel");
+-            ThrowMsg(Exception::InitFailed, "Error in smack_fsetlabel");
++        if (0 != smack_set_label_for_file(sockfd, XATTR_NAME_SMACKIPIN, desc.smackLabel.c_str())) {
++            LogError("Error in smack_set_label_for_file");
++            ThrowMsg(Exception::InitFailed, "Error in smack_set_label_for_file");
+         }
+     } else {
+         LogInfo("No smack on platform. Socket won't be securied with smack label!");
+-- 
+2.1.4
+

--- a/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
+++ b/meta-security-framework/recipes-security/security-manager/security-manager_git.bb
@@ -11,6 +11,7 @@ file://security-manager-policy-reload-do-not-depend-on-GNU-.patch \
 file://0001-Smack-rules-create-two-new-functions.patch \
 file://0002-app-install-implement-multiple-set-of-smack-rules.patch \
 file://c-11-replace-depracated-auto_ptr.patch \
+file://socket-manager-removes-tizen-specific-call.patch \
 "
 
 ##########################################


### PR DESCRIPTION
The project for smack user space library is normally
indeendant of tizen. However the library used by tizen
has specificities that should not be used normally.

This commit is needed to be able to switch the version
of smack user tools from the tizen one to the upstream:
https://github.com/smack-team/smack

Change-Id: I00e7e2935a4e20d90e2d2b8517c44dbd1a7fb87d
Signed-off-by: José Bollo jose.bollo@iot.bzh
