### PR TITLE
cynara: set mode for cynara/creds.conf

### DIFF
--- a/meta-security-framework/recipes-security/cynara/cynara.inc
+++ b/meta-security-framework/recipes-security/cynara/cynara.inc
@@ -82,7 +82,7 @@ do_install_append () {
    chmod a+rx ${D}/${sbindir}/cynara-db-migration
 
    install -d ${D}${sysconfdir}/cynara/
-   install ${S}/conf/creds.conf ${D}/${sysconfdir}/cynara/creds.conf
+   install -m 644 ${S}/conf/creds.conf ${D}/${sysconfdir}/cynara/creds.conf
 
    # No need to create empty directories except for those which
    # Cynara expects to find.


### PR DESCRIPTION
When using install, the default mode value is 0755
that installs the file cynara/creds.conf as an executable.
This patch removes that unexpected mode.

Change-Id: I290bc0a64ed242e43a929fd30a6e3004a9c5b2d0
Signed-off-by: José Bollo jose.bollo@iot.bzh
