### PR TITLE
toybox: enable use of libsmack on toybox.

### DIFF
--- a/meta-security-smack/recipes-extended/toybox/files/toybox_build-add-Missing-CFLAGS.patch
+++ b/meta-security-smack/recipes-extended/toybox/files/toybox_build-add-Missing-CFLAGS.patch
@@ -1,0 +1,42 @@
+From bf14101f314b3d28a772e14f484e731bb9bf43e5 Mon Sep 17 00:00:00 2001
+From: Alejandro Joya <alejandro.joya.cruz@intel.com>
+Date: Mon, 25 Jan 2016 12:56:41 -0600
+Subject: [PATCH] toybox_build: add Missing CFLAGS
+
+add CFLAGS to multiple builds to forward libraries location in Yocto.
+
+Signed-off-by: Alejandro Joya <alejandro.joya.cruz@intel.com>
+---
+ Makefile        | 2 +-
+ scripts/make.sh | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 1ea6929..0bb3c75 100644
+--- a/Makefile
++++ b/Makefile
+@@ -31,7 +31,7 @@ bloatcheck: toybox_old toybox_unstripped
+ 
+ generated/instlist: toybox_stuff
+ 	NOBUILD=1 scripts/make.sh
+-	$(HOSTCC) -I . scripts/install.c -o generated/instlist
++	$(HOSTCC) -I . $(CFLAGS) scripts/install.c -o generated/instlist
+ 
+ install_flat: generated/instlist
+ 	scripts/install.sh --symlink --force
+diff --git a/scripts/make.sh b/scripts/make.sh
+index 7ebe148..7d2d90a 100755
+--- a/scripts/make.sh
++++ b/scripts/make.sh
+@@ -212,7 +212,7 @@ fi
+ echo "generated/help.h"
+ if [ generated/config2help -ot scripts/config2help.c ]
+ then
+-  do_loudly $HOSTCC scripts/config2help.c -I . lib/xwrap.c lib/llist.c \
++  do_loudly $HOSTCC scripts/config2help.c $CFLAGS -I . lib/xwrap.c lib/llist.c \
+     lib/lib.c lib/portability.c -o generated/config2help || exit 1
+ fi
+ generated/config2help Config.in $KCONFIG_CONFIG > generated/help.h || exit 1
+-- 
+2.5.0
+

--- a/meta-security-smack/recipes-extended/toybox/toybox_%.bbappend
+++ b/meta-security-smack/recipes-extended/toybox/toybox_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+#add support to cflags as need it.
+SRC_URI += "file://toybox_build-add-Missing-CFLAGS.patch"
+
+#include CFLAGS to location of libraries.
+CFLAGS_prepend = "-I ${STAGING_DIR_HOST}${includedir_native}"
+
+do_configure() {
+	oe_runmake defconfig
+	# Disable killall5 as it isn't managed by update-alternatives
+	sed -e 's/CONFIG_KILLALL5=y/# CONFIG_KILLALL5 is not set/' -i .config
+	#Enable smack in toybox
+	sed -e 's/# CONFIG_TOYBOX_SMACK is not set/CONFIG_TOYBOX_SMACK=y/' -i .config
+}


### PR DESCRIPTION
It patch to toybox to use a default libraries environment used on yocto.
Also config toybox to be compiled using libsmack.h
Upstream-Status: Submitted(https://github.com/landley/toybox/pull/15)
Signed-off-by: Alejandro Joya alejandro.joya.cruz@intel.com
