### PR TITLE
util-linux_%.bbappend: add and enabled Smack feature

### DIFF
--- a/meta-security-smack/recipes-core/util-linux/util-linux_%.bbappend
+++ b/meta-security-smack/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,0 +1,8 @@
+# Enabling Smack support in util-linux enables special support
+# in [lib]mount for Smack mount options: they get removed if
+# Smack is not active in the current kernel. Important for
+# booting with "security=none" when userspace otherwise is
+# compiled to use Smack.
+
+PACKAGECONFIG_append_class-target_smack = " smack"
+PACKAGECONFIG[smack] = "--with-smack, --without-smack, smack-userspace"


### PR DESCRIPTION
Important for booting a userspace that was compiled for
Smack with a kernel where Smack is turned off (for example,
with security=none).

Without it, systemd fails to mount /tmp when the Smack
mount options get passed through to the kernel.

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
