### PR TITLE
smack-userspace: use upstream repository

### DIFF
--- a/meta-security-smack/recipes-security/smack/smack-userspace_git.bb
+++ b/meta-security-smack/recipes-security/smack/smack-userspace_git.bb
@@ -12,8 +12,10 @@ RPROVIDES_${PN} += "smack"
 
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 PV = "1.1.0+git${SRCPV}"
-SRCREV = "0bd2831dae7500fcfc080519ded5ae2bf6752226"
-SRC_URI += "git://review.tizen.org/platform/upstream/smack;nobranch=1"
+#SRCREV = "0bd2831dae7500fcfc080519ded5ae2bf6752226"
+#SRC_URI += "git://review.tizen.org/platform/upstream/smack;nobranch=1"
+SRC_URI += "git://github.com/jobol/smack.git;nobranch=1"
+SRCREV = "e24dcb3fa22ee8fddf7ce2012acda5f9c6fb7f85"
 S = "${WORKDIR}/git"
 
 inherit autotools


### PR DESCRIPTION
Using the tizen repository is not required anymore
since commit fca50aa.
Thus using the upstream version is a valuable
choice notabily because chsmack now includes
support of recursivity in options.

Change-Id: Ia01ca1fc1ee137222c304f508329d8d84c30651e
