### PR TITLE
populate sstate outside of TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,75 +19,7 @@ addons:
     - xvfb
     # Not needed, sdl removed from qemu below.
     # - libsdl1.2-dev
-install:
-  - git clone --depth=1 --single-branch --branch=$OE_CORE https://github.com/openembedded/openembedded-core.git
-  - ( cd openembedded-core && git clone --depth=1 --single-branch --branch=$BITBAKE https://github.com/openembedded/bitbake.git )
 script:
-  # The container environment has an limit of 2 hours per run. Everything else
-  # only gets 50 minutes.
-  #
-  # If we get killed, our sstate will not be uploaded and we won't be
-  # faster during the next invocation either. Therefore abort bitbake
-  # invocations which take too long ourselves, and then upload new
-  # sstate. We reserve 10 minutes for that (five was not enough
-  # sometimes).
-  - if uname -a | grep -q 3.13; then iscontainer=1; else iscontainer=; fi
-  - start=$(date +%s); if [ "$iscontainer" ]; then duration=120; else duration=50; fi; deadline=$(( $start + $duration * 60 - 10 * 60 ))
-  - echo "Started on $(date --date=@$start), must end at $(date --date=@$deadline)."
-  - echo $(df -B1048576 . | tail -1 | sed -e 's/[^ ]* *\([0-9]*\).*/\1/')
-  - . openembedded-core/oe-init-build-env
-  - sed -i -e "s;\(BBLAYERS.*\"\);\1 $(pwd)/../meta-security-smack $(pwd)/../meta-security-framework $(pwd)/../meta-integrity;" conf/bblayers.conf
-  # Simplify qemu compilation.
-  - echo 'PACKAGECONFIG_remove_pn-qemu-native = "sdl"' >>conf/local.conf
-  - echo 'ASSUME_PROVIDED_remove = "libsdl-native"' >>conf/local.conf
-  # Enable security components.
-  - echo 'DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} systemd pam smack dbus-cynara ima"' >>conf/local.conf
-  - echo 'OVERRIDES .= ":smack"' >>conf/local.conf
-  - echo 'VIRTUAL-RUNTIME_init_manager = "systemd"' >>conf/local.conf
-  - echo 'DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"' >>conf/local.conf
-  - echo 'VIRTUAL-RUNTIME_initscripts = ""' >>conf/local.conf
-  - echo 'CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " smack-userspace security-manager security-manager-policy cynara app-runas"' >>conf/local.conf
-  - echo 'INHERIT_append_pn-core-image-minimal = " ima-evm-rootfs"' >>conf/local.conf
-  # For testing...
-  - echo 'EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-dropbear"' >>conf/local.conf
-  - echo 'CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " python"' >>conf/local.conf
-  # Use Amazon S3 bucket as sstate cache if available.
-  - if [ -n "$AWS_BUCKET" ]; then echo "SSTATE_MIRRORS = \"file://.* http://$AWS_BUCKET.s3-website-${AWS_BUCKET_REGION:-us-east-1}.amazonaws.com/PATH\"" >>conf/local.conf; fi
-  # Can monitor less directories (it is all one file system) and
-  # accept lower security margins, because a failure is not that
-  # critical.
-  - echo 'BB_DISKMON_DIRS = " STOPTASKS,/tmp,500M,10K STOPTASKS,${DL_DIR},500M,10K ABORT,/tmp,100M,1K ABORT,${DL_DIR},100M,1K"' >>conf/local.conf
-  # Useful to avoid running out of disk space during the build.
-  - echo 'INHERIT += "rm_work_and_downloads"' >>conf/local.conf
-  - mkdir classes
-  - cp ../scripts/rm_work_and_downloads.bbclass classes
-  - echo 'BB_SCHEDULERS = "rmwork.RunQueueSchedulerRmWork"' >>conf/local.conf
-  - echo 'BB_SCHEDULER = "rmwork"' >>conf/local.conf
-  - PYTHONPATH=$TRAVIS_BUILD_DIR/scripts
-  - export PYTHONPATH
-  # Even with rm_work in place, running too many tasks in parallel can
-  # cause the disk to overflow temporarily and/or trigger the
-  # out-of-memory killer, so we allow only two tasks.  The default is
-  # too large because /proc/cpuinfo is misleading: it seems to show
-  # all CPUs on the host, although in reality (?) the environments only have
-  # two, according to
-  # http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
-  #
-  # The Trusty Beta environment has more RAM and thus can afford more parallelism.
-  # However, it also has a shorter overall runtime. If we end up with two heavy
-  # compile tasks (say, linux-yocto and qemu-native), then both compete for CPU
-  # time and neither of them manages to complete before the job gets killed.
-  # The solution for this is in the custom scheduler: it can limit the number of
-  # compile tasks separately from other tasks. This allows us to run many light-weight
-  # tasks (like setscene) in parallel without overloading the machine when compiling.
-  # However, we now may end up with 32 different recipes unpacked and ready for
-  # compilation, which takes up more disk space again.
-  - ( if [ "$iscontainer" ]; then echo 'BB_NUMBER_THREADS = "2"'; echo 'PARALLEL_MAKE = "-j4"'; else echo 'BB_NUMBER_THREADS = "32"';  echo 'BB_NUMBER_COMPILE_THREADS = "1"'; echo 'PARALLEL_MAKE = "-j8"'; fi ) >>conf/local.conf
-  # Dump our local.conf for debugging.
-  - tail -50 conf/local.conf
-  # Set up sstate-cache in a more visible, fixed location.
-  - mkdir -p $HOME/sstate-cache
-  - ln -s $HOME/sstate-cache .
   # Check for large directories (>= 1GB).
   - du -h $HOME | grep '^[0-9\.]\+G' || true
   - df -h .
@@ -96,6 +28,12 @@ script:
   # which are implemented in Ruby.
   - rm -rf $HOME/.rvm
   - df -h .
+  # Set up.
+  - SSTATE_CACHE=$HOME/sstate-cache
+  - export SSTATE_CACHE
+  - $(pwd)/scripts/travis-setup.sh $(pwd)
+  - . init-travis-build-env
+  - tail -50 conf/local.conf
   # And now building...
   - ../scripts/travis-cmd-wrapper.py --deadline=$deadline bitbake core-image-minimal app-runas mmap-smack-test tcp-smack-test udp-smack-test || BITBAKE_RESULT=1
   - df -h .
@@ -115,6 +53,6 @@ script:
   - echo "TEST_SUITES = \"ssh $tests\"" >>conf/local.conf
   # But not when using containers, because runqemu depends on TAP networking,
   # which requires root to set up.
-  - if [ ! "$iscontainer" ]; then xvfb-run ../scripts/travis-cmd-wrapper.py --deadline=$deadline -- bitbake -c testimage core-image-minimal || TEST_RESULT=1; for i in tmp*/work/*/core-image-minimal/*/temp/log.do_testimage tmp*/work/*/core-image-minimal/*/testimage/*log; do if [ -e $i ]; then echo "**** $i ****"; cat $i; fi; done; fi
+  - if [ "$buildenv" != "traviscontainer" ]; then xvfb-run ../scripts/travis-cmd-wrapper.py --deadline=$deadline -- bitbake -c testimage core-image-minimal || TEST_RESULT=1; for i in tmp*/work/*/core-image-minimal/*/temp/log.do_testimage tmp*/work/*/core-image-minimal/*/testimage/*log; do if [ -e $i ]; then echo "**** $i ****"; cat $i; fi; done; fi
   # Summarize results and set final job result.
   - echo "TravisCI result $TRAVIS_TEST_RESULT, build result ${BITBAKE_RESULT:-0}, test result ${TEST_RESULT:-0}"; if [ $TRAVIS_TEST_RESULT -eq 0 ] && ( [ "$BITBAKE_RESULT" ] || [ "$TEST_RESULT" ] ); then TRAVIS_TEST_RESULT=1; false; fi

--- a/scripts/sstate2s3.sh
+++ b/scripts/sstate2s3.sh
@@ -6,7 +6,7 @@
 # This file is licensed under the MIT license, see COPYING.MIT in
 # this source distribution for the terms.
 
-# Copies new files in $HOME/sstate-cache to the S3 bucket, if configured
+# Copies new files in $SSTATE_CACHE to the S3 bucket, if configured
 # via environment variables.
 #
 # Embedding these commands into .travis.yml itself turned out to be
@@ -14,24 +14,43 @@
 
 set -e
 
-if [ "$AWS_ACCESS_KEY" ] && [ "$AWS_SECRET_KEY" ] && [ "$AWS_BUCKET" ]; then
+S3EXCLUDE=$(mktemp)
+trap "rm -f $S3EXCLUDE" EXIT
+
+tos3exclude () {
+    sed -e "s;$SSTATE_CACHE/;;" >>$S3EXCLUDE
+}
+
+
+if ( [ "$AWS_ACCESS_KEY" ] && [ "$AWS_SECRET_KEY" ] || [ -e $HOME/.s3cfg ] ) && [ "$AWS_BUCKET" ]; then
     # State of sstate before cleaning. "tree" would give nicer output, but is
     # not available.
-    if [ "$DEBUG_OUTPUT" ]; then echo "current sstate-cache:"; find $HOME/sstate-cache \! -type d; FIND_DEBUG_PRINT=-print; echo "removing from sstate-cache:"; fi
+    if [ "$DEBUG_OUTPUT" ]; then
+        echo "current sstate-cache:"
+        if which tree >/dev/null 2>&1; then
+            tree $SSTATE_CACHE
+        else
+            find $SSTATE_CACHE/ \! -type d
+        fi
+        echo "checking sstate-cache"
+    fi
     # When we have successfully retrieved sstate from our HTTP server,
     # we end up with files in the top level directory and symlinks to
     # that in the real sstate location. We need to avoid deploying both
     # of these.
-    find $HOME/sstate-cache -type l -delete $FIND_DEBUG_PRINT
-    find $HOME/sstate-cache -maxdepth 1 -type f -delete $FIND_DEBUG_PRINT
+    find $SSTATE_CACHE/ -type l | tos3exclude
+    find $SSTATE_CACHE/ -maxdepth 1 -type f | tos3exclude
     # In addition, we also get .done files next to the symlinks (or real
     # files?).
-    find $HOME/sstate-cache -name *.done | while read file; do base=$(echo $file | sed -e 's/.done$//'); rm -f $base $file; if [ "$DEBUG_OUTPUT" ]; then echo $base; echo $file; fi; done
+    find $SSTATE_CACHE/ -name *.done | while read file; do base=$(echo $file | sed -e 's/.done$//'); (echo $base; echo $file) | tos3exclude; done
     # Finally, do_rm_work[_all.tgz.siginfo get created, but never downloaded via HTTP,
     # so there is no need to upload them.
-    find $HOME/sstate-cache \( -name *_rm_work.tgz.siginfo -o -name *_rm_work_all.tgz.siginfo \) -delete $FIND_DEBUG_PRINT
-    # Result of cleaning.
-    if [ "$DEBUG_OUTPUT" ]; then echo "cleaned sstate-cache:"; find $HOME/sstate-cache  \! -type d ; fi
+    (echo '*_rm_work.tgz.siginfo'; echo '*_rm_work_all.tgz.siginfo') | tos3exclude
+    if [ "$DEBUG_OUTPUT" ]; then
+        echo "excluded from sstate-cache:"
+        cat $S3EXCLUDE
+    fi
+
     # Now sync. s3cmd is more flexible than the TravisCI "deploy" or "artifacts" add-ons:
     # - we know that files are immutable, so we can simply skip existing ones
     #   (when running builds in parallel, more than one might end up creating the same file).
@@ -39,12 +58,14 @@ if [ "$AWS_ACCESS_KEY" ] && [ "$AWS_SECRET_KEY" ] && [ "$AWS_BUCKET" ]; then
     # - we can choose when to run it and whether it overlaps with testing.
     # - we can throw away the .rvm directory and thus get more free space.
     # On the other hand, "deploy" could also be configured to copy to other storages.
-    cat >$HOME/.s3cfg <<EOF
+    if [ ! -e $HOME/.s3cfg ]; then
+        cat >$HOME/.s3cfg <<EOF
 [default]
 access_key = $AWS_ACCESS_KEY
 secret_key = $AWS_SECRET_KEY
 use_https = False
 EOF
+    fi
     # Not supported by all versions of s3cmd, need to check.
     if s3cmd --help | grep -q -e --storage-class; then
         S3_STORAGE_CLASS=--storage-class=REDUCED_REDUNDANCY
@@ -53,7 +74,7 @@ EOF
     # TravisCI to abort the job ("The log length has exceeded the
     # limit of 4 Megabytes (this usually means that test suite is
     # raising the same exception over and over).").
-    s3cmd --no-progress --skip-existing $S3_STORAGE_CLASS sync $HOME/sstate-cache/ s3://travis-meta-intel-iot-security/
+    s3cmd $S3CMD_DRYRUN --no-progress --skip-existing --exclude-from=$S3EXCLUDE $S3_STORAGE_CLASS sync $SSTATE_CACHE/ s3://travis-meta-intel-iot-security/
 else
     echo "Not updating sstate in S3 bucket (no credentials or bucket)."
 fi

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+#
+# Combines setup, build and sstate-cache upload in a single script.
+# Invoke with env variables as needed by the individual components
+# and the build directory as parameter.
+#
+# sstate-cache can be reused between invocations, but should not
+# be shared with unrelated builds, because it will get uploaded
+# completely to S3.
+#
+# Example:
+# rm -rf /work/build-dir;
+# SSTATE_CACHE=/work/sstate-cache-meta-intel-iot-security \
+# DOWNLOADS=/work/downloads \
+# ... \
+# /work/meta-intel-iot-security/scripts/travis-build.sh /work/build-dir
+
+set -ex
+
+SRC_DIR=${1-$(pwd)}
+LAYERDIR=$(dirname $0)/..
+
+$LAYERDIR/scripts/travis-setup.sh $SRC_DIR
+. $SRC_DIR/init-travis-build-env
+bitbake core-image-minimal
+$LAYERDIR/scripts/sstate2s3.sh

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -93,6 +93,9 @@ VIRTUAL-RUNTIME_initscripts = ""
 CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " smack-userspace security-manager security-manager-policy cynara app-runas"
 INHERIT_append_pn-core-image-minimal = " ima-evm-rootfs"
 
+# Dump information about sstate usage.
+INHERIT += "buildstats-summary"
+
 # For testing...
 EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-dropbear"
 CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " python"

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -101,6 +101,18 @@ EOF
 # Use Amazon S3 bucket as sstate cache if available.
 if [ -n "$AWS_BUCKET" ]; then
     echo "SSTATE_MIRRORS = \"file://.* http://$AWS_BUCKET.s3-website-${AWS_BUCKET_REGION:-us-east-1}.amazonaws.com/PATH\"" >>conf/local.conf
+
+    # Make sstate less dependent on the build host.
+    # The URL must contain the x86_64-nativesdk-libc.tar.bz2
+    # that gets produced by "bitbake uninative-tarball".
+    # That needs to be done manually.
+    if [ -e $SRC_DIR/openembedded-core/meta/classes/uninative.bbclass ]; then
+        cat >>conf/local.conf <<EOF
+INHERIT += "uninative"
+UNINATIVE_URL = "http://$AWS_BUCKET.s3-website-${AWS_BUCKET_REGION:-us-east-1}.amazonaws.com/"
+UNINATIVE_CHECKSUM[x86_64] = "2d27033971da00c294b4b1dceee9c36e"
+EOF
+    fi
 fi
 
 case $buildenv in

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -1,0 +1,156 @@
+#! /bin/bash
+#
+# Invoke this script as
+# [SSTATE_CACHE/DOWNLOADS=<path to directory persistent sstates-cache and downloads dirs>] \
+# [AWS_BUCKET=... AWS_BUCKET_REGION=...] \
+# [OE_CORE=OE-core branch name] \
+# [BITBAKE=bitbake branch name] \
+# travis-setup.sh [<directory>]
+# and it'll set up that directory such that '. init-travis-build-env'
+# can be invoked in it.
+#
+# That directory is supposed to be empty or at most contain a a copy
+# of the meta-intel-iot-security repository.
+
+set -ex
+
+LAYERDIR=$(dirname $0)/..
+SRC_DIR=${1-$(pwd)}
+INIT=$SRC_DIR/init-travis-build-env
+
+mkdir -p $SRC_DIR
+cd $SRC_DIR
+git clone --depth=1 --single-branch --branch=${OE_CORE:-master} https://github.com/openembedded/openembedded-core.git
+( cd openembedded-core && git clone --depth=1 --single-branch --branch=${BITBAKE:-master} https://github.com/openembedded/bitbake.git )
+
+# Detect out-of-tree builds and create symlinks as needed.
+if [ ! -e $SRC_DIR/meta-security-smack/conf/layer.conf ]; then
+    for i in $(ls -1 $LAYERDIR); do
+        ln -s $LAYERDIR/$i .
+    done
+fi
+
+# Detect whether we run under Travis or on some other machine.
+if [ "$TRAVIS" != "true" ]; then
+    buildenv="native"
+elif uname -a | grep -q 3.13; then
+    buildenv="traviscontainer"
+else
+    buildenv="travistrusty"
+fi
+echo "buildenv=$buildenv" >>$INIT
+
+# The container environment has an limit of 2 hours per run. Everything else
+# only gets 50 minutes.
+#
+# If we get killed, our sstate will not be uploaded and we won't be
+# faster during the next invocation either. Therefore abort bitbake
+# invocations which take too long ourselves, and then upload new
+# sstate. We reserve 10 minutes for that (five was not enough
+# sometimes).
+start=$(date +%s)
+case $buildenv in
+    traviscontainer) duration=120;;
+    travistrusty) duration=50;;
+    *) duration=0;;
+esac
+if [ $duration -gt 0 ]; then
+    deadline=$(( $start + $duration * 60 - 10 * 60 ))
+    echo "Started on $(date --date=@$start), must end at $(date --date=@$deadline)."
+else
+    # Must set something. A week should be enough.
+    deadline=$(( $start + 7 * 24 * 60 * 60))
+fi
+echo "deadline=$deadline" >>$INIT
+
+echo ". $SRC_DIR/openembedded-core/oe-init-build-env $SRC_DIR/build" >>$INIT
+# This only works correctly in bash, hence /bin/bash.
+. openembedded-core/oe-init-build-env $SRC_DIR/build
+
+# Reuse downloads and/or sstate.
+if [ "$DOWNLOADS" ]; then
+    mkdir -p "$DOWNLOADS"
+    ln -s "$DOWNLOADS" downloads
+fi
+if [ "$SSTATE_CACHE" ]; then
+    mkdir -p "$SSTATE_CACHE"
+    ln -s "$SSTATE_CACHE" sstate-cache
+fi
+
+sed -i -e "s;\(BBLAYERS.*\"\);\1 $SRC_DIR/meta-security-smack $SRC_DIR/meta-security-framework $SRC_DIR/meta-integrity;" conf/bblayers.conf
+
+cat >>conf/local.conf <<EOF
+# Simplify qemu compilation.
+PACKAGECONFIG_remove_pn-qemu-native = "sdl"
+ASSUME_PROVIDED_remove = "libsdl-native"
+
+# Enable security components.
+DISTRO_FEATURES_append = " systemd pam smack dbus-cynara ima"
+OVERRIDES .= ":smack"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+VIRTUAL-RUNTIME_initscripts = ""
+CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " smack-userspace security-manager security-manager-policy cynara app-runas"
+INHERIT_append_pn-core-image-minimal = " ima-evm-rootfs"
+
+# For testing...
+EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-dropbear"
+CORE_IMAGE_EXTRA_INSTALL_append_pn-core-image-minimal = " python"
+EOF
+
+# Use Amazon S3 bucket as sstate cache if available.
+if [ -n "$AWS_BUCKET" ]; then
+    echo "SSTATE_MIRRORS = \"file://.* http://$AWS_BUCKET.s3-website-${AWS_BUCKET_REGION:-us-east-1}.amazonaws.com/PATH\"" >>conf/local.conf
+fi
+
+case $buildenv in
+    travis*)
+        cat >>conf/local.conf <<EOF
+# Can monitor less directories (it is all one file system) and
+# accept lower security margins, because a failure is not that
+# critical.
+BB_DISKMON_DIRS = " STOPTASKS,/tmp,500M,10K STOPTASKS,\${DL_DIR},500M,10K ABORT,/tmp,100M,1K ABORT,\${DL_DIR},100M,1K"
+# Useful to avoid running out of disk space during the build.
+INHERIT += "rm_work_and_downloads"
+BB_SCHEDULERS = "rmwork.RunQueueSchedulerRmWork"
+BB_SCHEDULER = "rmwork"
+EOF
+
+        mkdir -p classes
+        cp ../scripts/rm_work_and_downloads.bbclass classes
+        echo "PYTHONPATH=$TRAVIS_BUILD_DIR/scripts" >>$INIT
+        echo "export PYTHONPATH" >>$INIT
+
+        # Even with rm_work in place, running too many tasks in parallel can
+        # cause the disk to overflow temporarily and/or trigger the
+        # out-of-memory killer, so we allow only two tasks.  The default is
+        # too large because /proc/cpuinfo is misleading: it seems to show
+        # all CPUs on the host, although in reality (?) the environments only have
+        # two, according to
+        # http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+        #
+        # The Trusty Beta environment has more RAM and thus can afford more parallelism.
+        # However, it also has a shorter overall runtime. If we end up with two heavy
+        # compile tasks (say, linux-yocto and qemu-native), then both compete for CPU
+        # time and neither of them manages to complete before the job gets killed.
+        # The solution for this is in the custom scheduler: it can limit the number of
+        # compile tasks separately from other tasks. This allows us to run many light-weight
+        # tasks (like setscene) in parallel without overloading the machine when compiling.
+        # However, we now may end up with 32 different recipes unpacked and ready for
+        # compilation, which takes up more disk space again.
+        case $buildenv in
+            traviscontainer)
+                cat >>conf/local.conf <<EOF
+BB_NUMBER_THREADS = "2"
+PARALLEL_MAKE = "-j4"
+EOF
+                ;;
+            travistrusty)
+                cat >>conf/local.conf <<EOF
+BB_NUMBER_COMPILE_THREADS = "1"
+PARALLEL_MAKE = "-j8"
+EOF
+                ;;
+        esac
+        ;;
+esac


### PR DESCRIPTION
Slow compilation speed and the time limit make it cumbersome to keep TravisCI working. Now it is possible to compile on a faster machine and share the resulting sstate with TravisCI.
