### PR TITLE
integrity/systemd_%.bappend: add explicit /bin/sync

### DIFF
--- a/meta-integrity/recipes-core/systemd/files/machine-id-commit-sync.conf
+++ b/meta-integrity/recipes-core/systemd/files/machine-id-commit-sync.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/bin/sync

--- a/meta-integrity/recipes-core/systemd/files/random-seed-sync.conf
+++ b/meta-integrity/recipes-core/systemd/files/random-seed-sync.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStopPost=/bin/sync
+ExecStartPost=/bin/sync

--- a/meta-integrity/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-integrity/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://machine-id-commit-sync.conf \
+    file://random-seed-sync.conf \
+"
+
+do_install_append () {
+    for i in machine-id-commit random-seed; do
+        install -d ${D}/${systemd_system_unitdir}/systemd-$i.service.d
+        install -m 0644 ${WORKDIR}/$i-sync.conf ${D}/${systemd_system_unitdir}/systemd-$i.service.d
+    done
+}


### PR DESCRIPTION
/etc/machine-id and /var/lib/systemd/random-seed easily become
unreadable with a "Permission denied" error caused by IMA when
powering off hard.

That is because systemd creates the files without explicit fsync
(partly intentional, see
https://github.com/systemd/systemd/issues/2619) and then the
security.ima xattr created by the kernel does not get flushed to disk
for surprisingly long periods of time (definitely longer than the
usual 5 second commit timeout of ext4, see
https://sourceforge.net/p/linux-ima/mailman/message/34850685/ for a
discussion with the IMA developers about this).

The current workaround while waiting for systemd or IMA developers to
enhance crash resilience is to explicitly call /bin/sync after the
commands responsible for creating resp. updating the files are.

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
