### PR TITLE
linux-%.bbappend: Add IMA patch fixing unneeded re-appraisal

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-%.bbappend
+++ b/meta-integrity/recipes-kernel/linux/linux-%.bbappend
@@ -4,8 +4,26 @@ IMA_FILESEXTRAPATHS_yes := "${THISDIR}/linux:"
 IMA_FILESEXTRAPATHS_no := ""
 FILESEXTRAPATHS_prepend := "${IMA_FILESEXTRAPATHS_${IMA_ENABLED_HERE}}"
 
-# Kernel config fragment enabling IMA/EVM
-IMA_EVM_CFG_yes = " file://ima.cfg"
+# This patch is necessary to unpack archives with security.ima xattr
+# such that security.ima is taken from the archive. If the policy
+# allows hashing, unpatched kernels (at least up to 4.3) will replace
+# a signed hash in security.ima with a locally computed hash.
+#
+# Note that only bsdtar/libarchive are known to work; GNU tar sets
+# the security.ima on an empty file and the tries re-opening it for
+# writing its content, which then fails due to the IMA hash mismatch.
+#
+# Patches are potentially kernel version specific. Only some tested kernel versions
+# are supported here. Currently they all work with the same patch file, though.
+IMA_EVM_SETATTR_PATCH_4.1.18 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
+IMA_EVM_SETATTR_PATCH_4.1.15 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
+IMA_EVM_SETATTR_PATCH_4.4.3 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
+
+# Kernel config fragment enabling IMA/EVM and (where necessary and possible)
+# also patching the kernel.
+IMA_EVM_CFG_yes = " file://ima.cfg \
+                    ${@ d.getVar('IMA_EVM_SETATTR_PATCH_' + (d.getVar('LINUX_VERSION', True) or ''), True) or ''} \
+                  "
 IMA_EVM_CFG_no = ""
 SRC_URI_append = "${IMA_EVM_CFG_${IMA_ENABLED_HERE}}"
 

--- a/meta-integrity/recipes-kernel/linux/linux/0001-ima-fix-ima_inode_post_setattr.patch
+++ b/meta-integrity/recipes-kernel/linux/linux/0001-ima-fix-ima_inode_post_setattr.patch
@@ -1,0 +1,38 @@
+From e617354a2e6014baf8a29a62704f9cdfabf60e1f Mon Sep 17 00:00:00 2001
+From: Mimi Zohar <zohar@linux.vnet.ibm.com>
+Date: Mon, 29 Feb 2016 22:00:13 -0500
+Subject: [PATCH] ima: fix ima_inode_post_setattr
+
+Changing file metadata (eg. uid, guid) could result in having to
+re-appraise a file's integrity, but does not change the "new file"
+status nor the security.ima xattr.  The IMA_PERMIT_DIRECTIO and
+IMA_DIGSIG_REQUIRED flags are policy rule specific.  This patch
+only resets these flags, not the IMA_NEW_FILE or IMA_DIGSIG flags.
+
+With this patch, changing the file timestamp will not remove the
+file signature on new files.
+
+Upstream-Status: Submitted [https://sourceforge.net/p/linux-ima/mailman/message/34894743/]
+
+Reported-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Signed-off-by: Mimi Zohar <zohar@linux.vnet.ibm.com>
+---
+ security/integrity/ima/ima_appraise.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/security/integrity/ima/ima_appraise.c b/security/integrity/ima/ima_appraise.c
+index 1873b55..4ed4997 100644
+--- a/security/integrity/ima/ima_appraise.c
++++ b/security/integrity/ima/ima_appraise.c
+@@ -327,7 +327,7 @@ void ima_inode_post_setattr(struct dentry *dentry)
+ 	if (iint) {
+ 		iint->flags &= ~(IMA_APPRAISE | IMA_APPRAISED |
+ 				 IMA_APPRAISE_SUBMASK | IMA_APPRAISED_SUBMASK |
+-				 IMA_ACTION_FLAGS);
++				 IMA_PERMIT_DIRECTIO | IMA_DIGSIG_REQUIRED);
+ 		if (must_appraise)
+ 			iint->flags |= IMA_APPRAISE;
+ 	}
+-- 
+2.1.4
+


### PR DESCRIPTION
The patch taken from https://sourceforge.net/p/linux-ima/mailman/message/34894743/
makes IMA not to re-appraise a new file if only its timestamps
have changed during extraction from a tarball.

This is needed to avoid resetting the security.ima attribute for files
extracted from tarballs with software updates.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
