### PR TITLE
security-manager.inc: fix getVar() call

### DIFF
--- a/meta-security-framework/recipes-security/security-manager/security-manager.inc
+++ b/meta-security-framework/recipes-security/security-manager/security-manager.inc
@@ -53,7 +53,7 @@ python do_patch_append () {
     import os
     import shutil
     import glob
-    files = d.getVar('SECURITY_MANAGER_POLICY').split()
+    files = d.getVar('SECURITY_MANAGER_POLICY', True).split()
     if files:
         s = d.getVar('S', True)
         workdir = d.getVar('WORKDIR', True)


### PR DESCRIPTION
The "expand" parameter became mandatory in recent bitbake.

Not relevant for Ostro OS, but required elsewhere....

@ipuustin okay to merge?
