### PR TITLE
ima: Update patches fixing bsdtar and tar when IMA is enabled

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-%.bbappend
+++ b/meta-integrity/recipes-kernel/linux/linux-%.bbappend
@@ -15,9 +15,15 @@ FILESEXTRAPATHS_prepend := "${IMA_FILESEXTRAPATHS_${IMA_ENABLED_HERE}}"
 #
 # Patches are potentially kernel version specific. Only some tested kernel versions
 # are supported here. Currently they all work with the same patch file, though.
-IMA_EVM_SETATTR_PATCH_4.1.18 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
-IMA_EVM_SETATTR_PATCH_4.1.15 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
-IMA_EVM_SETATTR_PATCH_4.4.3 = "file://0001-ima-fix-ima_inode_post_setattr.patch"
+IMA_EVM_SETATTR_PATCH_4.1.18 = "file://0001-ima-fix-ima_inode_post_setattr.patch \
+                                file://0002-ima-add-support-for-creating-files-using-the-mknodat.patch \
+                               "
+IMA_EVM_SETATTR_PATCH_4.1.15 = "file://0001-ima-fix-ima_inode_post_setattr.patch \
+                                file://0002-ima-add-support-for-creating-files-using-the-mknodat.patch \
+                               "
+IMA_EVM_SETATTR_PATCH_4.4.3 = "file://0001-ima-fix-ima_inode_post_setattr.patch \
+                               file://0002-ima-add-support-for-creating-files-using-the-mknodat.patch \
+                              "
 
 # Kernel config fragment enabling IMA/EVM and (where necessary and possible)
 # also patching the kernel.

--- a/meta-integrity/recipes-kernel/linux/linux/0001-ima-fix-ima_inode_post_setattr.patch
+++ b/meta-integrity/recipes-kernel/linux/linux/0001-ima-fix-ima_inode_post_setattr.patch
@@ -1,6 +1,6 @@
-From e617354a2e6014baf8a29a62704f9cdfabf60e1f Mon Sep 17 00:00:00 2001
+From 45ea681ebc0dd44aaec5d3cc4143b9722070d3ac Mon Sep 17 00:00:00 2001
 From: Mimi Zohar <zohar@linux.vnet.ibm.com>
-Date: Mon, 29 Feb 2016 22:00:13 -0500
+Date: Tue, 8 Mar 2016 16:43:55 -0500
 Subject: [PATCH] ima: fix ima_inode_post_setattr
 
 Changing file metadata (eg. uid, guid) could result in having to
@@ -12,16 +12,17 @@ only resets these flags, not the IMA_NEW_FILE or IMA_DIGSIG flags.
 With this patch, changing the file timestamp will not remove the
 file signature on new files.
 
-Upstream-Status: Submitted [https://sourceforge.net/p/linux-ima/mailman/message/34894743/]
+Upstream-Status: Submitted [https://git.kernel.org/cgit/linux/kernel/git/zohar/linux-integrity.git/log/?h=next-4.7]
 
 Reported-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
 Signed-off-by: Mimi Zohar <zohar@linux.vnet.ibm.com>
 ---
  security/integrity/ima/ima_appraise.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ security/integrity/integrity.h        | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/security/integrity/ima/ima_appraise.c b/security/integrity/ima/ima_appraise.c
-index 1873b55..4ed4997 100644
+index 4df493e..a384ba1 100644
 --- a/security/integrity/ima/ima_appraise.c
 +++ b/security/integrity/ima/ima_appraise.c
 @@ -327,7 +327,7 @@ void ima_inode_post_setattr(struct dentry *dentry)
@@ -29,10 +30,22 @@ index 1873b55..4ed4997 100644
  		iint->flags &= ~(IMA_APPRAISE | IMA_APPRAISED |
  				 IMA_APPRAISE_SUBMASK | IMA_APPRAISED_SUBMASK |
 -				 IMA_ACTION_FLAGS);
-+				 IMA_PERMIT_DIRECTIO | IMA_DIGSIG_REQUIRED);
++				 IMA_ACTION_RULE_FLAGS);
  		if (must_appraise)
  			iint->flags |= IMA_APPRAISE;
  	}
+diff --git a/security/integrity/integrity.h b/security/integrity/integrity.h
+index 0fc9519..f9decae 100644
+--- a/security/integrity/integrity.h
++++ b/security/integrity/integrity.h
+@@ -28,6 +28,7 @@
+ 
+ /* iint cache flags */
+ #define IMA_ACTION_FLAGS	0xff000000
++#define IMA_ACTION_RULE_FLAGS	0x06000000
+ #define IMA_DIGSIG		0x01000000
+ #define IMA_DIGSIG_REQUIRED	0x02000000
+ #define IMA_PERMIT_DIRECTIO	0x04000000
 -- 
-2.1.4
+2.5.0
 

--- a/meta-integrity/recipes-kernel/linux/linux/0002-ima-add-support-for-creating-files-using-the-mknodat.patch
+++ b/meta-integrity/recipes-kernel/linux/linux/0002-ima-add-support-for-creating-files-using-the-mknodat.patch
@@ -1,0 +1,138 @@
+From baaec960e9e7be0b526eaf831b079ddfe5c15124 Mon Sep 17 00:00:00 2001
+From: Mimi Zohar <zohar@linux.vnet.ibm.com>
+Date: Thu, 10 Mar 2016 18:19:20 +0200
+Subject: [PATCH] ima: add support for creating files using the mknodat
+ syscall
+
+Commit 3034a14 "ima: pass 'opened' flag to identify newly created files"
+stopped identifying empty files as new files.  However new empty files
+can be created using the mknodat syscall.  On systems with IMA-appraisal
+enabled, these empty files are not labeled with security.ima extended
+attributes properly, preventing them from subsequently being opened in
+order to write the file data contents.  This patch marks these empty
+files, created using mknodat, as new in order to allow the file data
+contents to be written.
+
+Files with security.ima xattrs containing a file signature are considered
+"immutable" and can not be modified.  The file contents need to be
+written, before signing the file.  This patch relaxes this requirement
+for new files, allowing the file signature to be written before the file
+contents.
+
+Upstream-Status: Submitted [https://git.kernel.org/cgit/linux/kernel/git/zohar/linux-integrity.git/log/?h=next-4.7]
+
+Signed-off-by: Mimi Zohar <zohar@linux.vnet.ibm.com>
+---
+ fs/namei.c                            |  2 ++
+ include/linux/ima.h                   |  7 ++++++-
+ security/integrity/ima/ima_appraise.c |  3 +++
+ security/integrity/ima/ima_main.c     | 32 +++++++++++++++++++++++++++++++-
+ 4 files changed, 42 insertions(+), 2 deletions(-)
+
+diff --git a/fs/namei.c b/fs/namei.c
+index ccd7f98..19502da 100644
+--- a/fs/namei.c
++++ b/fs/namei.c
+@@ -3526,6 +3526,8 @@ retry:
+ 	switch (mode & S_IFMT) {
+ 		case 0: case S_IFREG:
+ 			error = vfs_create(path.dentry->d_inode,dentry,mode,true);
++			if (!error)
++				ima_post_path_mknod(dentry);
+ 			break;
+ 		case S_IFCHR: case S_IFBLK:
+ 			error = vfs_mknod(path.dentry->d_inode,dentry,mode,
+diff --git a/include/linux/ima.h b/include/linux/ima.h
+index 120ccc5..7f51971 100644
+--- a/include/linux/ima.h
++++ b/include/linux/ima.h
+@@ -20,7 +20,7 @@ extern void ima_file_free(struct file *file);
+ extern int ima_file_mmap(struct file *file, unsigned long prot);
+ extern int ima_module_check(struct file *file);
+ extern int ima_fw_from_file(struct file *file, char *buf, size_t size);
+-
++extern void ima_post_path_mknod(struct dentry *dentry);
+ #else
+ static inline int ima_bprm_check(struct linux_binprm *bprm)
+ {
+@@ -52,6 +52,11 @@ static inline int ima_fw_from_file(struct file *file, char *buf, size_t size)
+ 	return 0;
+ }
+ 
++static inline void ima_post_path_mknod(struct dentry *dentry)
++{
++	return;
++}
++
+ #endif /* CONFIG_IMA */
+ 
+ #ifdef CONFIG_IMA_APPRAISE
+diff --git a/security/integrity/ima/ima_appraise.c b/security/integrity/ima/ima_appraise.c
+index 4df493e..20806ea 100644
+--- a/security/integrity/ima/ima_appraise.c
++++ b/security/integrity/ima/ima_appraise.c
+@@ -274,6 +274,11 @@ out:
+ 		     xattr_value->type != EVM_IMA_XATTR_DIGSIG)) {
+ 			if (!ima_fix_xattr(dentry, iint))
+ 				status = INTEGRITY_PASS;
++		} else if ((inode->i_size == 0) &&
++			   (iint->flags & IMA_NEW_FILE) &&
++			   (xattr_value &&
++			    xattr_value->type == EVM_IMA_XATTR_DIGSIG)) {
++			status = INTEGRITY_PASS;
+ 		}
+ 		integrity_audit_msg(AUDIT_INTEGRITY_DATA, inode, filename,
+ 				    op, cause, rc, 0);
+diff --git a/security/integrity/ima/ima_main.c b/security/integrity/ima/ima_main.c
+index eeee00dc..705bf78 100644
+--- a/security/integrity/ima/ima_main.c
++++ b/security/integrity/ima/ima_main.c
+@@ -242,7 +242,8 @@ static int process_measurement(struct file *file, int mask, int function,
+ 		ima_audit_measurement(iint, pathname);
+ 
+ out_digsig:
+-	if ((mask & MAY_WRITE) && (iint->flags & IMA_DIGSIG))
++	if ((mask & MAY_WRITE) && (iint->flags & IMA_DIGSIG) &&
++	     !(iint->flags & IMA_NEW_FILE))
+ 		rc = -EACCES;
+ 	kfree(xattr_value);
+ out_free:
+@@ -310,6 +311,35 @@ int ima_file_check(struct file *file, int mask, int opened)
+ EXPORT_SYMBOL_GPL(ima_file_check);
+ 
+ /**
++ * ima_post_path_mknod - mark as a new inode
++ * @dentry: newly created dentry
++ *
++ * Mark files created via the mknodat syscall as new, so that the
++ * file data can be written later.
++ */
++void ima_post_path_mknod(struct dentry *dentry)
++{
++	struct integrity_iint_cache *iint;
++	struct inode *inode;
++	int must_appraise;
++
++	if (!dentry || !dentry->d_inode)
++		return;
++
++	inode = dentry->d_inode;
++	if (inode->i_size != 0)
++		return;
++
++	must_appraise = ima_must_appraise(inode, MAY_ACCESS, FILE_CHECK);
++	if (!must_appraise)
++		return;
++
++	iint = integrity_inode_get(inode);
++	if (iint)
++		iint->flags |= IMA_NEW_FILE;
++}
++
++/**
+  * ima_module_check - based on policy, collect/store/appraise measurement.
+  * @file: pointer to the file to be measured/appraised
+  *
+-- 
+2.5.0
+


### PR DESCRIPTION
The patch introduced in the commit
c2c8e10f9e9452f205cbfd273852f879fccaeec7
has been recently updated and extended by Mimi Zohar to accomodate fixes
for GNU tar relaxing the requirement for new files to have a valid
signature if they are created with mknodat() and empty.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com

PS. I checked the patches apply to linux-yocto-4.4 cleanly.
