### PR TITLE
meta-intel-iot-security: drop support for dizzy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - OE_CORE=master BITBAKE=master
   - OE_CORE=jethro BITBAKE=1.28
   - OE_CORE=fido BITBAKE=1.26
-  - OE_CORE=dizzy BITBAKE=1.24
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the individual layer README's for further instructions.
 
 Build and unit testing under [TravisCI][] is configured against
 different OpenEmbedded core branches in .travis.yml. Currently master,
-jethro, fido and dizzy are covered.
+jethro, and fido are covered.
 
 Two different [TravisCI environments][] are used:
 


### PR DESCRIPTION
The kernel in dizzy seems to be too old to work with the /proc changes
in "punch SMACK-holes for /proc net interface entries" (commit
28a811ce4).

It is unclear whether there is still interest in dizzy; if there is,
that will have to be supported on a branch by someone who is
interested in maintaining it.
