### PR TITLE
keyutils: fix build error with OE-core master

### DIFF
--- a/meta-security-framework/recipes-security/keyutils/keyutils_1.5.8.bb
+++ b/meta-security-framework/recipes-security/keyutils/keyutils_1.5.8.bb
@@ -20,8 +20,6 @@ SRC_URI_append_x86-64 = " file://keyutils_fix_x86-64_cflags.patch"
 
 S = "${WORKDIR}/git"
 
-inherit autotools
-
 INSTALL_FLAGS = " \
 BINDIR=${bindir} \
 SBINDIR=${sbindir} \


### PR DESCRIPTION
Fixes a build error with OE-core master.
