### PR TITLE
dbus-cynara: fix installation for multilib packages

### DIFF
--- a/meta-security-framework/recipes-core/dbus/dbus-cynara_1.8.18.bb
+++ b/meta-security-framework/recipes-core/dbus/dbus-cynara_1.8.18.bb
@@ -39,7 +39,7 @@ REQUIRED_DISTRO_FEATURES += "smack"
 # Only the main package gets created here, everything else remains in the
 # normal dbus recipe.
 do_install_append () {
-    for i in ${@' '.join([d.getVar('D', True) + x for x in (' '.join([d.getVar('FILES_dbus-cynara-' + p, True) or '' for p in ['lib', 'dev', 'staticdev', 'doc', 'locale', 'ptest']])).split()])}; do
+    for i in ${@' '.join([d.getVar('D', True) + x for x in (' '.join([d.getVar('FILES_${PN}-' + p, True) or '' for p in ['lib', 'dev', 'staticdev', 'doc', 'locale', 'ptest']])).split()])}; do
         rm -rf $i
     done
 

--- a/meta-security-framework/recipes-core/dbus/dbus_%.bbappend
+++ b/meta-security-framework/recipes-core/dbus/dbus_%.bbappend
@@ -4,7 +4,7 @@
 # -> dbus).
 do_install_append_class-target () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'dbus-cynara', 'true', 'false', d)}; then
-        for i in ${@' '.join([d.getVar('D', True) + x for x in (d.getVar('FILES_dbus', True) or '').split()])}; do
+        for i in ${@' '.join([d.getVar('D', True) + x for x in (d.getVar('FILES_${PN}', True) or '').split()])}; do
             rm -rf $i
         done
 


### PR DESCRIPTION
In a multilib config, when building things like lib32-dbus-cynara, the
package name is 'lib32-dbus-cynara' instead of 'dbus-cynara'. The
install_append's for dbus-cynara and dbus were only finding files for
the trivial non-multilib case.
This patch makes them use ${PN} so they work in both cases.

Signed-off-by: Frederico Cadete frederico.cadete@awtce.be
