### PR TITLE
smack-userspace: bump to version 1.2.x

### DIFF
--- a/meta-security-smack/recipes-security/smack/smack-userspace_git.bb
+++ b/meta-security-smack/recipes-security/smack/smack-userspace_git.bb
@@ -2,7 +2,6 @@ DESCRIPTION = "Selection of tools for developers working with Smack"
 HOMEPAGE = "https://github.com/smack-team/smack"
 SECTION = "Security/Access Control"
 LICENSE = "LGPL-2.1"
-PV = "1.0.5"
 
 # Alias needed to satisfy dependencies in other recipes.
 # This recipe itself cannot be named "smack" because that
@@ -11,9 +10,9 @@ PROVIDES = "smack"
 RPROVIDES_${PN} += "smack"
 
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
-PV = "1.1.0+git${SRCPV}"
-SRCREV = "f9515f4a36e1cbdf852f14fb46e6b92914383a1b"
-SRC_URI += "git://github.com/smack-team/smack.git;protocol=https;branch=v1.1.x"
+PV = "1.2.0+git${SRCPV}"
+SRCREV = "d82bac7dac69823fd40015dffad1a128505a2258"
+SRC_URI += "git://github.com/smack-team/smack.git;protocol=https;branch=v1.2.x"
 S = "${WORKDIR}/git"
 
 inherit autotools


### PR DESCRIPTION
This new version includes some minor evolutions:
- chsmack:
  - print error message if obtaining access label fails
  - add recursive option
- libsmack:
  - add function for configuring relabel-self interface
  - Support filesystems that don't fill in d_type
- smackcipso:
  - improved help

Change-Id: I77e16c68182b60d51ddcabdc72fd3105e260bffc
Signed-off-by: José Bollo jose.bollo@iot.bzh
