### PR TITLE
oeqa/runtime/ima.py : fix case issue if IMA disabled

### DIFF
--- a/meta-integrity/lib/oeqa/runtime/ima.py
+++ b/meta-integrity/lib/oeqa/runtime/ima.py
@@ -72,7 +72,11 @@ class IMACheck(oeRuntimeTest):
 
     def test_ima_overwrite(self):
         ''' Test if IMA prevents overwriting signed files '''
-        signed_file = "/bin/sh"
+        status, output = self.target.run("find /bin -type f")
+        self.assertEqual(status, 0 , "ssh to device fail: %s" %output)  
+        signed_file = output.strip().split()[0]
+        print("\n signed_file is %s" % signed_file)
         status, output = self.target.run(" echo 'foo' >> %s" %signed_file)
-        self.assertIn("Text file busy", output,
+        self.assertNotEqual(status, 0 , "Signed file could be written")
+        self.assertIn("Permission denied", output,
                       "Did not find expected error message. Got: %s" %output)


### PR DESCRIPTION
/bin/sh is a symbolic link , so it always get 'Text file busy' no matter
IMA disabled or not.

The fix uses an uncommon binary 'arping' to check this to decrease
side-effect if IMA disabled.

Signed-off-by: Wu Dawei daweix.wu@intel.com
