### PR TITLE
smack: recipes-test: fix "ldflags" package QA test

### DIFF
--- a/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
+++ b/meta-security-smack/recipes-test/mmap-smack-test/mmap-smack-test.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://mmap.c"
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} mmap.c -o mmap_test
+    ${CC} mmap.c ${LDFLAGS} -o mmap_test
 }
 
 do_install() {

--- a/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bb
+++ b/meta-security-smack/recipes-test/tcp-smack-test/tcp-smack-test.bb
@@ -9,8 +9,8 @@ SRC_URI = "file://tcp_server.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} tcp_client.c -o tcp_client
-    ${CC} tcp_server.c -o tcp_server
+    ${CC} tcp_client.c ${LDFLAGS} -o tcp_client
+    ${CC} tcp_server.c ${LDFLAGS} -o tcp_server
 }
 
 do_install() {

--- a/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bb
+++ b/meta-security-smack/recipes-test/udp-smack-test/udp-smack-test.bb
@@ -9,8 +9,8 @@ SRC_URI = "file://udp_server.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} udp_client.c -o udp_client
-    ${CC} udp_server.c -o udp_server
+    ${CC} udp_client.c ${LDFLAGS} -o udp_client
+    ${CC} udp_server.c ${LDFLAGS} -o udp_server
 }
 
 do_install() {


### PR DESCRIPTION
After a change in openembedded-core, we're now getting more accurate
information about components that do not properly use the build system
LDFLAGS in linking.

See http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=a98a8180863ff45b477a1f8439ebcec21151d282

The test utils in recipes-test do not seem to use ${LDFLAGS} and
we're hit by a package QA test error.

Add ${LDFLAGS} into do_compile to get rid of the failure.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
