### PR TITLE
coreutils: enable SMACK for target only

### DIFF
--- a/meta-security-smack/recipes-core/coreutils/coreutils_%.bbappend
+++ b/meta-security-smack/recipes-core/coreutils/coreutils_%.bbappend
@@ -3,5 +3,5 @@
 # explicitly otherwise.
 EXTRA_OECONF_SMACK = "--disable-libsmack"
 EXTRA_OECONF_SMACK_smack = "--enable-libsmack"
-EXTRA_OECONF_append = " ${EXTRA_OECONF_SMACK}"
-DEPENDS_append_smack = " smack"
+EXTRA_OECONF_append_class-target = " ${EXTRA_OECONF_SMACK}"
+DEPENDS_append_smack_class-target = " smack"


### PR DESCRIPTION
All smack related calls in coreutils check is_smack_enabled(). This
may or may not work with coreutils-native and nativesdk-coreutils
depending on how the host is configured.

To have this consistent for all users, (and to minimize dependencies
for native/nativesdk), enable SMACK for target only.

The real need for this change was triggered by glib upgrade in oe-core
(361dc99) that added a new dependency that ended up needing (a missing)
nativesdk-smack when the meta-toolchain was built. It would have been
an option to add nativesdk in BBCLASSEXTEND for smack. However, this
change sounded more reasonable.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>