### PR TITLE
base-files: ensure smack postinst script works during do_rootfs

### DIFF
--- a/meta-security-smack/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-security-smack/recipes-core/base-files/base-files_%.bbappend
@@ -42,6 +42,7 @@ EOF
 # - works for directories which are not packaged by default when empty
 RDEPENDS_${PN}_append_smack = " smack-userspace"
 DEPENDS_append_smack = " smack-userspace-native"
+PACKAGE_WRITE_DEPS_append_smack = " smack-userspace-native"
 pkg_postinst_${PN}_smack() {
     #!/bin/sh -e
 


### PR DESCRIPTION
The pkg_postinst we are adding calls chsmack, so we need to
add that to PKG_WRITE_DEPS to ensure it's available during
do_rootfs to avoid it failing and being deferred until first boot.

Signed-off-by: Paul Eggleton <paul.eggleton@linux.intel.com>