### PR TITLE
meta-security-smack: layer.conf: set LAYERSERIES_COMPAT

### DIFF
--- a/meta-security-framework/classes/xattr-images.bbclass
+++ b/meta-security-framework/classes/xattr-images.bbclass
@@ -20,7 +20,7 @@ EXTRA_IMAGECMD_jffs2_append = " --with-xattr"
 # The GNU documentation does not specify whether --xattrs-include is necessary.
 # In practice, it turned out to be not needed when creating archives and
 # required when extracting, but it seems prudent to use it in both cases.
-IMAGE_DEPENDS_tar_append = " tar-replacement-native"
+do_image_tar[depends] += "tar-replacement-native:do_populate_sysroot"
 EXTRANATIVEPATH += "tar-native"
 IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
 

--- a/meta-security-smack/conf/layer.conf
+++ b/meta-security-smack/conf/layer.conf
@@ -10,3 +10,6 @@ BBFILES := "${BBFILES} \
 BBFILE_COLLECTIONS += "security-smack"
 BBFILE_PATTERN_security-smack := "^${LAYERDIR}/"
 BBFILE_PRIORITY_security-smack = "8"
+
+LAYERSERIES_COMPAT_security-smack = "rocko sumo"
+


### PR DESCRIPTION
Set LAYERSERIES_COMPAT to indicate that this layer is compatible with
both the rocko and sumo branches.

Signed-off-by: Paul Eggleton <paul.eggleton@linux.intel.com>